### PR TITLE
Refactoring Interfaces

### DIFF
--- a/include/enfield/Support/ApproxTSFinder.h
+++ b/include/enfield/Support/ApproxTSFinder.h
@@ -4,18 +4,22 @@
 #include "enfield/Support/TokenSwapFinder.h"
 
 namespace efd {
+    /// \brief 4-Approximative polynomial algorithm.
+    ///
+    /// Miltzow et al.
+    /// DOI: 10.4230/LIPIcs.ESA.2016.66
     class ApproxTSFinder : public TokenSwapFinder {
         public:
             typedef ApproxTSFinder* Ref;
             typedef std::unique_ptr<ApproxTSFinder> uRef;
 
-            ApproxTSFinder(Graph::sRef graph);
+        protected:
+            void preprocess() override;
+            SwapSeq findImpl(const Assign& from, const Assign& to) override;
 
-            SwapSeq find(Assign from, Assign to) override;
-            SwapSeq find(Graph::Ref graph, Assign from, Assign to) override;
-
+        public:
             /// \brief Creates an instance of this class.
-            static uRef Create(Graph::sRef graph = nullptr);
+            static uRef Create();
     };
 }
 

--- a/include/enfield/Support/ExpTSFinder.h
+++ b/include/enfield/Support/ExpTSFinder.h
@@ -5,6 +5,15 @@
 #include <map>
 
 namespace efd {
+    /// \brief Brute force solution to the Token Swap Finder.
+    ///
+    /// It first preprocesses the given graph, generating all permutations
+    /// from one starting point. This is the expensive part of the process.
+    /// It takes O(|Q|!).
+    ///
+    /// At each query, it renames the qubits and finds the swaps needed to
+    /// solve that query.
+    /// Each query only takes O(|Q|).
     class ExpTSFinder : public TokenSwapFinder {
         public:
             typedef std::unique_ptr<ExpTSFinder> uRef;
@@ -14,19 +23,16 @@ namespace efd {
             std::vector<SwapSeq> mSwaps;
 
             void genAllAssigns(uint32_t n);
-            void preprocess(Graph::Ref graph);
-            uint32_t getTargetId(Assign source, Assign target);
+            uint32_t getTargetId(const Assign& source, const Assign& target);
+
+            void preprocess() override;
+            SwapSeq findImpl(const Assign& from, const Assign& to) override;
 
         public:
             std::vector<Assign> mAssigns;
 
-            ExpTSFinder(Graph::sRef graph);
-
-            SwapSeq find(Assign from, Assign to) override;
-            SwapSeq find(Graph::Ref graph, Assign from, Assign to) override;
-
             /// \brief Creates an instance of this class.
-            static uRef Create(Graph::sRef graph = nullptr);
+            static uRef Create();
     };
 }
 

--- a/include/enfield/Support/TokenSwapFinder.h
+++ b/include/enfield/Support/TokenSwapFinder.h
@@ -5,20 +5,25 @@
 #include "enfield/Support/Defs.h"
 
 namespace efd {
+    /// \brief Interface for solving the Token Swap Problem.
     class TokenSwapFinder {
         public:
             typedef TokenSwapFinder* Ref;
             typedef std::unique_ptr<TokenSwapFinder> uRef;
 
         protected:
-            Graph::sRef mG;
-            TokenSwapFinder(Graph::sRef graph) : mG(graph) {}
+            Graph::Ref mG;
+            TokenSwapFinder();
+
+            void checkGraphSet();
+            virtual void preprocess() = 0;
+            virtual SwapSeq findImpl(const Assign& from, const Assign& to) = 0;
 
         public:
+            /// \brief Sets the `Graph`.
+            void setGraph(Graph::Ref graph);
             /// \brief Finds a swap sequence to reach \p to from \p from.
-            virtual SwapSeq find(Assign from, Assign to) = 0;
-            /// \brief Finds a swap sequence to reach \p to from \p from in \p graph.
-            virtual SwapSeq find(Graph::Ref graph, Assign from, Assign to) = 0;
+            SwapSeq find(const Assign& from, const Assign& to);
     };
 }
 

--- a/include/enfield/Transform/Allocators/Allocators.def
+++ b/include/enfield/Transform/Allocators/Allocators.def
@@ -1,8 +1,13 @@
-EFD_FIRSTLAST(dynprog, wqubiter)
 EFD_ALLOCATOR(dynprog, DynprogQAllocator)
 EFD_ALLOCATOR(grdy, GreedyCktQAllocator)
 EFD_ALLOCATOR(ibm, IBMQAllocator)
-EFD_ALLOCATOR(bmt, BoundedMappingTreeQAllocator)
+EFD_ALLOCATOR_BMT(bmt, SeqNCandidateIterator,
+                       FirstCandidateSelector,
+                       FirstCandidateSelector,
+                       GeoDistanceSwapCEstimator,
+                       GeoNearestLQPProcessor,
+                       BestMSSelector,
+                       ApproxTSFinder)
 EFD_ALLOCATOR_SIMPLE(wpm, WeightedSIMappingFinder, PathGuidedSolBuilder)
 EFD_ALLOCATOR_SIMPLE(random, RandomMappingFinder, PathGuidedSolBuilder)
 EFD_ALLOCATOR_SIMPLE(qubiter, IdentityMappingFinder, QbitterSolBuilder)

--- a/include/enfield/Transform/Allocators/Allocators.h
+++ b/include/enfield/Transform/Allocators/Allocators.h
@@ -8,30 +8,25 @@
 
 namespace efd {
     enum class Allocator {
-#define EFD_FIRSTLAST(_First_, _Last_)
+        first,
 #define EFD_ALLOCATOR(_Name_, _Class_)\
         Q_##_Name_,
 #define EFD_ALLOCATOR_SIMPLE(_Name_, _Finder_, _Builder_)\
         Q_##_Name_,
+#define EFD_ALLOCATOR_BMT(_Name_, _NCI_, _CS_, _PSS_, _SCE_, _LQPP_, _MSS_, _TSF_)\
+        Q_##_Name_,
 #include "enfield/Transform/Allocators/Allocators.def"
-#undef EFD_FIRSTLAST
 #undef EFD_ALLOCATOR
 #undef EFD_ALLOCATOR_SIMPLE
+#undef EFD_ALLOCATOR_BMT
+        last
     };
 
-#define EFD_FIRSTLAST(_First_, _Last_)\
-    typedef EnumString<Allocator,\
-                       Allocator::Q_##_First_,\
-                       Allocator::Q_##_Last_>\
+    typedef EnumString<Allocator, Allocator::first, Allocator::last>
             EnumAllocator;
-#define EFD_ALLOCATOR(_Name_, _Class_)
-#define EFD_ALLOCATOR_SIMPLE(_Name_, _Finder_, _Builder_)
-#include "enfield/Transform/Allocators/Allocators.def"
-#undef EFD_FIRSTLAST
-#undef EFD_ALLOCATOR
-#undef EFD_ALLOCATOR_SIMPLE
 
-    typedef Registry<QbitAllocator::uRef, ArchGraph::sRef, EnumAllocator> AllocatorRegistry;
+    typedef Registry<QbitAllocator::uRef, ArchGraph::sRef, EnumAllocator>
+            AllocatorRegistry;
 
     void InitializeAllQbitAllocators();
     /// \brief Returns true if there is an allocator mapped by \p key;
@@ -43,16 +38,18 @@ namespace efd {
             AllocatorRegistry::ArgTy arg);
 
 
-#define EFD_FIRSTLAST(_First_, _Last_)
 #define EFD_ALLOCATOR(_Name_, _Class_) \
     AllocatorRegistry::RetTy Create##_Class_(AllocatorRegistry::ArgTy arg);
 #define EFD_ALLOCATOR_SIMPLE(_Name_, _Finder_, _Builder_) \
     AllocatorRegistry::RetTy Create##_Finder_##With##_Builder_\
     (AllocatorRegistry::ArgTy arg);
+#define EFD_ALLOCATOR_BMT(_Name_, _NCI_, _CS_, _PSS_, _SCE_, _LQPP_, _MSS_, _TSF_) \
+    AllocatorRegistry::RetTy CreateBMT##_NCI_##_CS_##_PSS_##_SCE_##_LQPP_##_MSS_##_TSF_\
+    (AllocatorRegistry::ArgTy arg);
 #include "enfield/Transform/Allocators/Allocators.def"
-#undef EFD_FIRSTLAST
 #undef EFD_ALLOCATOR
 #undef EFD_ALLOCATOR_SIMPLE
+#undef EFD_ALLOCATOR_BMT
 }
 
 #endif

--- a/include/enfield/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.h
+++ b/include/enfield/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.h
@@ -4,6 +4,9 @@
 #include "enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h"
 
 namespace efd {
+    /// \brief Sequential iterator.
+    ///
+    /// It follows the order of the instructions given by the iterators.
     class SeqNCandidateIterator : public NodeCandidateIterator {
         private:
             Node::Iterator mIt;
@@ -15,12 +18,17 @@ namespace efd {
             bool hasNext() override;
     };
 
+    /// \brief Gets the first \em maxCandidates from \em candidates.
     class FirstCandidateSelector : public CandidateSelector {
         public:
             bmt::CandidateVector select(uint32_t maxCandidates,
                                         const bmt::CandidateVector& candidates) override;
     };
 
+    /// \brief The estimation is the sum of all distances.
+    ///
+    /// Distace is the number of edges between the place where a token is,
+    /// and the place where it should be.
     class GeoDistanceSwapCEstimator : public SwapCostEstimator {
         private:
             bmt::Matrix mDist;
@@ -31,6 +39,7 @@ namespace efd {
             uint32_t estimate(const Mapping& fromM, const Mapping& toM) override;
     };
 
+    /// \brief Forces \em toM to map all qubits mapped in \em fromM.
     class GeoNearestLQPProcessor : public LiveQubitsPreProcessor {
         private:
             uint32_t mPQubits;
@@ -42,6 +51,7 @@ namespace efd {
             void process(const Graph::Ref g, Mapping& fromM, Mapping& toM) override;
     };
 
+    /// \brief Selects the line that yielded the best cost.
     class BestMSSelector : public MapSeqSelector {
         public:
             bmt::Vector select(const bmt::TIMatrix& mem) override;

--- a/include/enfield/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.h
+++ b/include/enfield/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.h
@@ -10,19 +10,28 @@ namespace efd {
     class SeqNCandidateIterator : public NodeCandidateIterator {
         private:
             Node::Iterator mIt;
-            Node::Iterator mEnd;
+
+        protected:
+            Node::Ref nextImpl() override;
+            bool hasNextImpl() override;
 
         public:
-            SeqNCandidateIterator(const Node::Iterator& it, const Node::Iterator& end);
-            Node::Ref next() override;
-            bool hasNext() override;
+            typedef SeqNCandidateIterator* Ref;
+            typedef std::unique_ptr<SeqNCandidateIterator> uRef;
+
+            static uRef Create();
     };
 
     /// \brief Gets the first \em maxCandidates from \em candidates.
     class FirstCandidateSelector : public CandidateSelector {
         public:
+            typedef FirstCandidateSelector* Ref;
+            typedef std::unique_ptr<FirstCandidateSelector> uRef;
+
             bmt::CandidateVector select(uint32_t maxCandidates,
                                         const bmt::CandidateVector& candidates) override;
+
+            static uRef Create();
     };
 
     /// \brief The estimation is the sum of all distances.
@@ -34,9 +43,15 @@ namespace efd {
             bmt::Matrix mDist;
             bmt::Vector distanceFrom(Graph::Ref g, uint32_t u);
 
+        protected:
+            void preprocess() override;
+            uint32_t estimateImpl(const Mapping& fromM, const Mapping& toM) override;
+
         public:
-            void fixGraph(Graph::Ref g) override;
-            uint32_t estimate(const Mapping& fromM, const Mapping& toM) override;
+            typedef GeoDistanceSwapCEstimator* Ref;
+            typedef std::unique_ptr<GeoDistanceSwapCEstimator> uRef;
+
+            static uRef Create();
     };
 
     /// \brief Forces \em toM to map all qubits mapped in \em fromM.
@@ -48,13 +63,23 @@ namespace efd {
             uint32_t getNearest(const Graph::Ref g, uint32_t u, const Assign& assign);
 
         public:
+            typedef GeoNearestLQPProcessor* Ref;
+            typedef std::unique_ptr<GeoNearestLQPProcessor> uRef;
+
             void process(const Graph::Ref g, Mapping& fromM, Mapping& toM) override;
+
+            static uRef Create();
     };
 
     /// \brief Selects the line that yielded the best cost.
     class BestMSSelector : public MapSeqSelector {
         public:
+            typedef BestMSSelector* Ref;
+            typedef std::unique_ptr<BestMSSelector> uRef;
+
             bmt::Vector select(const bmt::TIMatrix& mem) override;
+
+            static uRef Create();
     };
 }
 

--- a/include/enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h
+++ b/include/enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h
@@ -6,11 +6,13 @@
 
 namespace efd {
     namespace bmt {
+        /// \brief Composition of each candidate in phase 1.
         struct Candidate {
             Mapping m;
             uint32_t cost;
         };
 
+        /// \brief Necessary information for getting the combinations in phase 2.
         struct TracebackInfo {
             Mapping m;
             uint32_t parent;
@@ -30,6 +32,7 @@ namespace efd {
         typedef std::vector<Mapping> MappingVector;
         typedef std::vector<std::vector<Mapping>> MappingVectorCollection;
 
+        /// \brief Keep track of the sequence of `Mapping`s and its cost.
         struct MappingSeq {
             MappingVector mappingV;
             uint32_t mappingCost;
@@ -38,6 +41,7 @@ namespace efd {
         typedef std::vector<MappingSeq> MapSeqCollection;
         typedef std::vector<SwapSeq> SwapSeqCollection;
 
+        /// \brief Holds the sequence of `Mapping`s and `Swaps`to be executed.
         struct MappingSwapSequence {
             MappingVector mappingV;
             SwapSeqCollection swapSeqCollection;
@@ -48,39 +52,65 @@ namespace efd {
         typedef std::vector<PPartition> PPartitionCollection;
     }
 
+    /// \brief Interface for getting the next `Node` to be processed in phase 1.
     struct NodeCandidateIterator {
         typedef NodeCandidateIterator* Ref;
         typedef std::unique_ptr<NodeCandidateIterator> uRef;
+        /// \brief Returns the next `Node`.
         virtual Node::Ref next() = 0;
+        /// \brief Returns whether there are still `Node`s to be processed.
         virtual bool hasNext() = 0;
     };
 
+    /// \brief Interface for selecting candidates (if they are greater than
+    /// a max) in phase 1.
     struct CandidateSelector {
         typedef CandidateSelector* Ref;
         typedef std::unique_ptr<CandidateSelector> uRef;
+        /// \brief Selects \em maxCandidates from \em candidates.
         virtual bmt::CandidateVector select(uint32_t maxCandidates,
                                             const bmt::CandidateVector& candidates) = 0;
     };
 
+    /// \brief Interface for estimating the number of swaps in phase 2.
     struct SwapCostEstimator {
         typedef SwapCostEstimator* Ref;
         typedef std::unique_ptr<SwapCostEstimator> uRef;
+        /// \brief Fixes the graph for preprocessing purposes.
         virtual void fixGraph(Graph::Ref g) = 0;
+        /// \brief Estimates the number of swaps to go from \em fromM to \toM.
         virtual uint32_t estimate(const Mapping& fromM, const Mapping& toM) = 0;
     };
 
+    /// \brief Interface for preparing the `Mapping`s for fixing the Live
+    /// Qubits problem.
     struct LiveQubitsPreProcessor {
         typedef LiveQubitsPreProcessor* Ref;
         typedef std::unique_ptr<LiveQubitsPreProcessor> uRef;
+        /// \brief Processes `Mapping` \em toM, based on the graph \em g and on the
+        /// last `Mapping` \em fromM.
         virtual void process(const Graph::Ref g, Mapping& fromM, Mapping& toM) = 0;
     };
 
+    /// \brief Selects a number of line numbers from the memoized matrix. 
     struct MapSeqSelector {
         typedef MapSeqSelector* Ref;
         typedef std::unique_ptr<MapSeqSelector> uRef;
+        /// \brief Returns a vector with the line indexes chosen to be tracebacked.
         virtual bmt::Vector select(const bmt::TIMatrix& mem) = 0;
     };
 
+    /// \brief Subgraph Isomorphism based Qubit Allocator.
+    ///
+    /// This QAllocator is split into 3 phases:
+    ///     1. Partitions the program into a number of smaller programs,
+    ///         and find all* subgraph isomorphisms from the graph of that
+    ///         program to the coupling graph (architecture);
+    ///     2. Dynamic programming that tests all combinations of subgraph
+    ///         isomorphisms, while estimating the cost of glueing them
+    ///         together;
+    ///     3. Reconstructs the selected sequence of subgraph isomorphisms
+    ///         into a program.
     class BoundedMappingTreeQAllocator : public StdSolutionQAllocator {
         public:
             typedef BoundedMappingTreeQAllocator* Ref;
@@ -116,6 +146,21 @@ namespace efd {
             StdSolution buildStdSolution(QModule::Ref qmod) override;
 
         public:
+            /// \brief Sets the implementation for iterating the `Node`s in phase 1.
+            void setNodeCandidateIterator(NodeCandidateIterator::uRef it);
+            /// \brief Sets the implementation for selecting the children in phase 1.
+            void setChildrenSelector(CandidateSelector::uRef sel);
+            /// \brief Sets the implementation for selecting the partial solutions in phase 1.
+            void setPartialSolutionSelector(CandidateSelector::uRef sel);
+            /// \brief Sets the implementation for estimating the swap cost in phase 2.
+            void setSwapCostEstimator(SwapCostEstimator::uRef est);
+            /// \brief Sets the implementation for fixing the Live Qubits problem in phase 2.
+            void setLiveQubitsPreProcessor(LiveQubitsPreProcessor::uRef proc);
+            /// \brief Sets the implementation for selecting the `Mapping` sequences in phase 2.
+            void setMapSeqSelector(MapSeqSelector::uRef sel);
+            /// \brief Sets the implementation for finding the swap sequences in phase 3.
+            void setTokenSwapFinder(TokenSwapFinder::uRef finder);
+
             static uRef Create(ArchGraph::sRef ag);
     };
 }

--- a/include/enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h
+++ b/include/enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h
@@ -56,10 +56,23 @@ namespace efd {
     struct NodeCandidateIterator {
         typedef NodeCandidateIterator* Ref;
         typedef std::unique_ptr<NodeCandidateIterator> uRef;
+
+        NodeCandidateIterator();
+
+        /// \brief Sets the `QModule` to be iterated.
+        void setQModule(QModule::Ref qmod);
         /// \brief Returns the next `Node`.
-        virtual Node::Ref next() = 0;
+        Node::Ref next();
         /// \brief Returns whether there are still `Node`s to be processed.
-        virtual bool hasNext() = 0;
+        bool hasNext();
+
+        protected:
+            QModule::Ref mMod;
+            bool isFirst;
+
+            void checkQModuleSet();
+            virtual Node::Ref nextImpl() = 0;
+            virtual bool hasNextImpl() = 0;
     };
 
     /// \brief Interface for selecting candidates (if they are greater than
@@ -76,10 +89,21 @@ namespace efd {
     struct SwapCostEstimator {
         typedef SwapCostEstimator* Ref;
         typedef std::unique_ptr<SwapCostEstimator> uRef;
-        /// \brief Fixes the graph for preprocessing purposes.
-        virtual void fixGraph(Graph::Ref g) = 0;
+
+        SwapCostEstimator();
+
+        /// \brief Sets the `Graph`.
+        void setGraph(Graph::Ref g);
         /// \brief Estimates the number of swaps to go from \em fromM to \toM.
-        virtual uint32_t estimate(const Mapping& fromM, const Mapping& toM) = 0;
+        uint32_t estimate(const Mapping& fromM, const Mapping& toM);
+
+        protected:
+            Graph::Ref mG;
+
+            void checkGraphSet();
+            virtual void preprocess() = 0;
+            virtual uint32_t estimateImpl(const Mapping& fromM,
+                                          const Mapping& toM) = 0;
     };
 
     /// \brief Interface for preparing the `Mapping`s for fixing the Live

--- a/include/enfield/Transform/Allocators/QbitAllocator.h
+++ b/include/enfield/Transform/Allocators/QbitAllocator.h
@@ -68,7 +68,6 @@ namespace efd {
     std::string MappingToString(Mapping m);
 }
 
-extern efd::Stat<uint32_t> TotalCost;
 extern efd::Opt<uint32_t> SwapCost;
 extern efd::Opt<uint32_t> RevCost;
 extern efd::Opt<uint32_t> LCXCost;

--- a/include/enfield/Transform/IntrinsicGateCostPass.h
+++ b/include/enfield/Transform/IntrinsicGateCostPass.h
@@ -1,0 +1,23 @@
+#ifndef __EFD_INTRINSIC_GATE_COST_PASS_H__
+#define __EFD_INTRINSIC_GATE_COST_PASS_H__
+
+#include "enfield/Transform/QModule.h"
+#include "enfield/Transform/Pass.h"
+
+namespace efd {
+    class IntrinsicGateCostPass : public PassT<uint32_t> {
+        public:
+            typedef IntrinsicGateCostPass* Ref;
+            typedef std::unique_ptr<IntrinsicGateCostPass> uRef;
+            typedef std::shared_ptr<IntrinsicGateCostPass> sRef;
+
+            static uint8_t ID;
+
+            bool run(QModule::Ref qmod) override;
+
+            /// \brief Returns a new instance of this class.
+            static uRef Create();
+    };
+};
+
+#endif

--- a/include/enfield/Transform/QModuleQualityEvalPass.h
+++ b/include/enfield/Transform/QModuleQualityEvalPass.h
@@ -7,12 +7,17 @@
 #include <map>
 
 namespace efd {
+    /// \brief Holds the evaluation metrics for an allocation.
     struct QModuleQuality {
         uint32_t mDepth;
         uint32_t mGates;
         uint32_t mWeightedCost;
     };
 
+    /// \brief Evaluates a `QModule`.
+    ///
+    /// Computes the depth of the circuit, the number of gates, and
+    /// a weighted sum for each gate.
     class QModuleQualityEvalPass : public PassT<QModuleQuality> {
         public:
             typedef QModuleQualityEvalPass* Ref;

--- a/include/enfield/Transform/QModuleQualityEvalPass.h
+++ b/include/enfield/Transform/QModuleQualityEvalPass.h
@@ -1,0 +1,37 @@
+#ifndef __EFD_QMODULE_QUALITY_EVAL_PASS_H__
+#define __EFD_QMODULE_QUALITY_EVAL_PASS_H__
+
+#include "enfield/Transform/QModule.h"
+#include "enfield/Transform/Pass.h"
+
+#include <map>
+
+namespace efd {
+    struct QModuleQuality {
+        uint32_t mDepth;
+        uint32_t mGates;
+        uint32_t mWeightedCost;
+    };
+
+    class QModuleQualityEvalPass : public PassT<QModuleQuality> {
+        public:
+            typedef QModuleQualityEvalPass* Ref;
+            typedef std::unique_ptr<QModuleQualityEvalPass> uRef;
+            typedef std::shared_ptr<QModuleQualityEvalPass> sRef;
+            typedef std::map<std::string, uint32_t> MapGateUInt;
+
+        private:
+            MapGateUInt mGatesW;
+
+        public:
+            static uint8_t ID;
+
+            QModuleQualityEvalPass(MapGateUInt gatesW);
+            bool run(QModule::Ref qmod) override;
+
+            /// \brief Returns a new instance of this class.
+            static uRef Create(MapGateUInt gatesW);
+    };
+};
+
+#endif

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -7,4 +7,5 @@ add_library (EfdSupport
     Stats.cpp
     ExpTSFinder.cpp
     ApproxTSFinder.cpp
-    Defs.cpp)
+    Defs.cpp
+    TokenSwapFinder.cpp)

--- a/lib/Support/TokenSwapFinder.cpp
+++ b/lib/Support/TokenSwapFinder.cpp
@@ -1,0 +1,22 @@
+#include "enfield/Support/TokenSwapFinder.h"
+
+using namespace efd;
+
+TokenSwapFinder::TokenSwapFinder() : mG(nullptr) {}
+
+void TokenSwapFinder::checkGraphSet() {
+    if (mG == nullptr) {
+        ERR << "Set the `Graph` for TokenSwapFinder." << std::endl;
+        ExitWith(ExitCode::EXIT_unreachable);
+    }
+}
+
+void TokenSwapFinder::setGraph(Graph::Ref graph) {
+    mG = graph;
+    preprocess();
+}
+
+SwapSeq TokenSwapFinder::find(const Assign& from, const Assign& to) {
+    checkGraphSet();
+    return findImpl(from, to);
+}

--- a/lib/Transform/Allocators/Allocators.cpp
+++ b/lib/Transform/Allocators/Allocators.cpp
@@ -5,6 +5,9 @@
 #include "enfield/Transform/Allocators/SimpleQAllocator.h"
 #include "enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h"
 
+#include "enfield/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.h"
+#include "enfield/Support/ApproxTSFinder.h"
+
 #include "enfield/Transform/Allocators/Simple/WeightedSIMappingFinder.h"
 #include "enfield/Transform/Allocators/Simple/RandomMappingFinder.h"
 #include "enfield/Transform/Allocators/Simple/IdentityMappingFinder.h"
@@ -19,15 +22,18 @@ namespace efd {
 }
 
 template <> std::vector<std::string> efd::EnumAllocator::mStrVal {
-#define EFD_FIRSTLAST(_First_, _Last_)
+    "None",
 #define EFD_ALLOCATOR(_Name_, _Class_) \
     "Q_"#_Name_,
 #define EFD_ALLOCATOR_SIMPLE(_Name_, _Finder_, _Builder_) \
     "Q_"#_Name_,
+#define EFD_ALLOCATOR_BMT(_Name_, _NCI_, _CS_, _PSS_, _SCE_, _LQPP_, _MSS_, _TSF_) \
+    "Q_"#_Name_,
 #include "enfield/Transform/Allocators/Allocators.def"
-#undef EFD_FIRSTLAST
 #undef EFD_ALLOCATOR
 #undef EFD_ALLOCATOR_SIMPLE
+#undef EFD_ALLOCATOR_BMT
+    "None",
 };
 
 // -------------- Static -----------------
@@ -41,15 +47,17 @@ static efd::AllocatorRegistryPtr GetRegistry() {
 
 // -------------- Public Functions -----------------
 void efd::InitializeAllQbitAllocators() {
-#define EFD_FIRSTLAST(_First_, _Last_)
 #define EFD_ALLOCATOR(_Name_, _Class_) \
     RegisterQbitAllocator(Allocator::Q_##_Name_, Create##_Class_);
 #define EFD_ALLOCATOR_SIMPLE(_Name_, _Finder_, _Builder_) \
     RegisterQbitAllocator(Allocator::Q_##_Name_, Create##_Finder_##With##_Builder_);
+#define EFD_ALLOCATOR_BMT(_Name_, _NCI_, _CS_, _PSS_, _SCE_, _LQPP_, _MSS_, _TSF_) \
+    RegisterQbitAllocator(Allocator::Q_##_Name_,\
+                          CreateBMT##_NCI_##_CS_##_PSS_##_SCE_##_LQPP_##_MSS_##_TSF_);
 #include "enfield/Transform/Allocators/Allocators.def"
-#undef EFD_FIRSTLAST
 #undef EFD_ALLOCATOR
 #undef EFD_ALLOCATOR_SIMPLE
+#undef EFD_ALLOCATOR_BMT
 }
 
 bool efd::HasAllocator(EnumAllocator key) {
@@ -66,7 +74,6 @@ efd::CreateQbitAllocator(EnumAllocator key, AllocatorRegistry::ArgTy arg) {
 }
 
 // -------------- Allocator Functions -----------------
-#define EFD_FIRSTLAST(_First_, _Last_)
 #define EFD_ALLOCATOR(_Name_, _Class_) \
     efd::AllocatorRegistry::RetTy efd::Create##_Class_(AllocatorRegistry::ArgTy arg) {\
         return _Class_::Create(arg);\
@@ -79,8 +86,21 @@ efd::CreateQbitAllocator(EnumAllocator key, AllocatorRegistry::ArgTy arg) {
         allocator->setSolBuilder(_Builder_::Create());\
         return std::move(allocator);\
     }
+#define EFD_ALLOCATOR_BMT(_Name_, _NCI_, _CS_, _PSS_, _SCE_, _LQPP_, _MSS_, _TSF_) \
+    efd::AllocatorRegistry::RetTy\
+    efd::CreateBMT##_NCI_##_CS_##_PSS_##_SCE_##_LQPP_##_MSS_##_TSF_(AllocatorRegistry::ArgTy arg) {\
+        auto allocator = BoundedMappingTreeQAllocator::Create(arg);\
+        allocator->setNodeCandidateIterator(_NCI_::Create());\
+        allocator->setChildrenSelector(_CS_::Create());\
+        allocator->setPartialSolutionSelector(_PSS_::Create());\
+        allocator->setSwapCostEstimator(_SCE_::Create());\
+        allocator->setLiveQubitsPreProcessor(_LQPP_::Create());\
+        allocator->setMapSeqSelector(_MSS_::Create());\
+        allocator->setTokenSwapFinder(_TSF_::Create());\
+        return std::move(allocator);\
+    }
 #include "enfield/Transform/Allocators/Allocators.def"
-#undef EFD_FIRSTLAST
 #undef EFD_ALLOCATOR
 #undef EFD_ALLOCATOR_SIMPLE
+#undef EFD_ALLOCATOR_BMT
 

--- a/lib/Transform/Allocators/BoundedMappingTreeQAllocator.cpp
+++ b/lib/Transform/Allocators/BoundedMappingTreeQAllocator.cpp
@@ -431,6 +431,41 @@ StdSolution BoundedMappingTreeQAllocator::buildStdSolution(QModule::Ref qmod) {
     return sol;
 }
 
+void BoundedMappingTreeQAllocator::setNodeCandidateIterator
+(NodeCandidateIterator::uRef it) {
+    mNCIterator = std::move(it);
+}
+
+void BoundedMappingTreeQAllocator::setChildrenSelector
+(CandidateSelector::uRef sel) {
+    mChildrenCSelector = std::move(sel);
+}
+
+void BoundedMappingTreeQAllocator::setPartialSolutionSelector
+(CandidateSelector::uRef sel) {
+    mPartialSolutionCSelector = std::move(sel);
+}
+
+void BoundedMappingTreeQAllocator::setSwapCostEstimator
+(SwapCostEstimator::uRef est) {
+    mCostEstimator = std::move(est);
+}
+
+void BoundedMappingTreeQAllocator::setLiveQubitsPreProcessor
+(LiveQubitsPreProcessor::uRef proc) {
+    mLQPProcessor = std::move(proc);
+}
+
+void BoundedMappingTreeQAllocator::setMapSeqSelector
+(MapSeqSelector::uRef sel) {
+    mMSSelector = std::move(sel);
+}
+
+void BoundedMappingTreeQAllocator::setTokenSwapFinder
+(TokenSwapFinder::uRef finder) {
+    mTSFinder = std::move(finder);
+}
+
 BoundedMappingTreeQAllocator::uRef
 BoundedMappingTreeQAllocator::Create(ArchGraph::sRef ag) {
     return uRef(new BoundedMappingTreeQAllocator(ag));

--- a/lib/Transform/Allocators/BoundedMappingTreeQAllocator.cpp
+++ b/lib/Transform/Allocators/BoundedMappingTreeQAllocator.cpp
@@ -20,8 +20,60 @@ static Opt<uint32_t> MaxPartialSolutions
 ("-bmt-max-partial", "Limits the max number of partial solutions per step.",
  std::numeric_limits<uint32_t>::max(), false);
 
+// --------------------- NodeCandidateIterator ------------------------
+NodeCandidateIterator::NodeCandidateIterator() : mMod(nullptr), isFirst(true) {}
+
+void NodeCandidateIterator::setQModule(QModule::Ref qmod) {
+    mMod = qmod;
+}
+
+Node::Ref NodeCandidateIterator::next() {
+    checkQModuleSet();
+    return nextImpl();
+}
+
+bool NodeCandidateIterator::hasNext() {
+    checkQModuleSet();
+    return hasNextImpl();
+}
+
+void NodeCandidateIterator::checkQModuleSet() {
+    if (mMod == nullptr) {
+        ERR << "Set the `QModule` for NodeCandidateIterator." << std::endl;
+        ExitWith(ExitCode::EXIT_unreachable);
+    }
+}
+
+// --------------------- SwapCostEstimator ------------------------
+SwapCostEstimator::SwapCostEstimator() : mG(nullptr) {}
+
+void SwapCostEstimator::setGraph(Graph::Ref g) {
+    mG = g;
+    preprocess();
+}
+
+uint32_t SwapCostEstimator::estimate(const Mapping& fromM, const Mapping& toM) {
+    checkGraphSet();
+    return estimateImpl(fromM, toM);
+}
+
+void SwapCostEstimator::checkGraphSet() {
+    if (mG == nullptr) {
+        ERR << "Set the `Graph` for SwapCostEstimator." << std::endl;
+        ExitWith(ExitCode::EXIT_unreachable);
+    }
+}
+
+// --------------------- BoundedMappingTreeQAllocator ------------------------
 BoundedMappingTreeQAllocator::BoundedMappingTreeQAllocator(ArchGraph::sRef ag)
-    : StdSolutionQAllocator(ag) {}
+    : StdSolutionQAllocator(ag),
+      mNCIterator(nullptr),
+      mChildrenCSelector(nullptr),
+      mPartialSolutionCSelector(nullptr),
+      mCostEstimator(nullptr),
+      mLQPProcessor(nullptr),
+      mMSSelector(nullptr),
+      mTSFinder(nullptr) {}
 
 CandidateVector
 BoundedMappingTreeQAllocator::extendCandidates(Dep& dep,
@@ -381,35 +433,27 @@ StdSolution BoundedMappingTreeQAllocator::phase3(const MappingSwapSequence& mss)
 }
 
 StdSolution BoundedMappingTreeQAllocator::buildStdSolution(QModule::Ref qmod) {
-    if (mNCIterator.get() == nullptr) {
-        mNCIterator.reset(new SeqNCandidateIterator(qmod->stmt_begin(), qmod->stmt_end()));
+    if (mNCIterator.get() == nullptr ||
+                mChildrenCSelector.get() == nullptr ||
+                mPartialSolutionCSelector.get() == nullptr ||
+                mCostEstimator.get() == nullptr ||
+                mLQPProcessor.get() == nullptr ||
+                mMSSelector.get() == nullptr ||
+                mTSFinder.get() == nullptr) {
+        ERR << "Define the `BoundedMappingTreeQAllocator` interfaces:" << std::endl;
+        ERR << "    NodeCandidateIterator: " << mNCIterator.get() << std::endl;
+        ERR << "    mChildrenCSelector: " << mChildrenCSelector.get() << std::endl;
+        ERR << "    mPartialSolutionCSelector: " << mPartialSolutionCSelector.get() << std::endl;
+        ERR << "    mCostEstimator: " << mCostEstimator.get() << std::endl;
+        ERR << "    mLQPProcessor: " << mLQPProcessor.get() << std::endl;
+        ERR << "    mMSSelector: " << mMSSelector.get() << std::endl;
+        ERR << "    mTSFinder: " << mTSFinder.get() << std::endl;
+        ExitWith(ExitCode::EXIT_unreachable);
     }
 
-    if (mChildrenCSelector.get() == nullptr) {
-        mChildrenCSelector.reset(new FirstCandidateSelector());
-    }
-
-    if (mPartialSolutionCSelector.get() == nullptr) {
-        mPartialSolutionCSelector.reset(new FirstCandidateSelector());
-    }
-
-    if (mCostEstimator.get() == nullptr) {
-        mCostEstimator.reset(new GeoDistanceSwapCEstimator());
-    }
-
-    if (mLQPProcessor.get() == nullptr) {
-        mLQPProcessor.reset(new GeoNearestLQPProcessor());
-    }
-
-    if (mMSSelector.get() == nullptr) {
-        mMSSelector.reset(new BestMSSelector());
-    }
-
-    if (mTSFinder.get() == nullptr) {
-        mTSFinder.reset(new ApproxTSFinder(mArchGraph));
-    }
-
-    mCostEstimator->fixGraph(mArchGraph.get());
+    mNCIterator->setQModule(qmod);
+    mCostEstimator->setGraph(mArchGraph.get());
+    mTSFinder->setGraph(mArchGraph.get());
 
     mMaxChildren = MaxChildren.getVal();
     mMaxPartial = MaxPartialSolutions.getVal();

--- a/lib/Transform/Allocators/DynprogQAllocator.cpp
+++ b/lib/Transform/Allocators/DynprogQAllocator.cpp
@@ -57,9 +57,10 @@ efd::StdSolution efd::DynprogQAllocator::buildStdSolution(QModule::Ref qmod) {
         ->getData()
         .getDependencies();
 
-    ExpTSFinder tsp(mArchGraph);
-    auto permutations = tsp.mAssigns;
+    ExpTSFinder tsp;
+    tsp.setGraph(mArchGraph.get());
 
+    auto permutations = tsp.mAssigns;
     uint32_t archQ = mArchGraph->size();
     const uint32_t SWAP_COST = SwapCost.getVal();
     const uint32_t REV_COST = RevCost.getVal();

--- a/lib/Transform/Allocators/QbitAllocator.cpp
+++ b/lib/Transform/Allocators/QbitAllocator.cpp
@@ -21,15 +21,6 @@ static efd::Stat<double> ReplaceTime
 ("ReplaceTime", "Time to replace all qubits to the corresponding architechture ones.");
 static efd::Stat<double> RenameTime
 ("RenameTime", "Time to rename all qubits to the mapped qubits.");
-efd::Stat<uint32_t> TotalCost
-("TotalCost", "Total cost after allocating the qubits.");
-
-efd::Opt<uint32_t> SwapCost
-("-swap-cost", "Cost of using a swap function.", 7, false);
-efd::Opt<uint32_t> RevCost
-("-rev-cost", "Cost of using a reverse edge.", 4, false);
-efd::Opt<uint32_t> LCXCost
-("-lcx-cost", "Cost of using long cnot gate.", 10, false);
 
 efd::Assign efd::GenAssignment(uint32_t archQ, Mapping mapping, bool fill) {
     uint32_t progQ = mapping.size();

--- a/lib/Transform/CMakeLists.txt
+++ b/lib/Transform/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library (EfdTransform
     Pass.cpp
     PassCache.cpp
     QModule.cpp
+    QModuleQualityEvalPass.cpp
     RenameQbitsPass.cpp
     ReverseEdgesPass.cpp
     SemanticVerifierPass.cpp

--- a/lib/Transform/CMakeLists.txt
+++ b/lib/Transform/CMakeLists.txt
@@ -1,22 +1,23 @@
 add_subdirectory (Allocators)
 
 add_library (EfdTransform
+    ArchVerifierPass.cpp
+    CircuitGraph.cpp
+    CircuitGraphBuilderPass.cpp
+    CNOTLBOWrapperPass.cpp
+    DependencyBuilderPass.cpp
+    DependencyGraphBuilderPass.cpp
+    Driver.cpp
+    FlattenPass.cpp
+    InlineAllPass.cpp
+    IntrinsicGateCostPass.cpp
+    LayersBuilderPass.cpp
+    LayerBasedOrderingWrapperPass.cpp
     Pass.cpp
     PassCache.cpp
     QModule.cpp
-    XbitToNumberPass.cpp
-    DependencyBuilderPass.cpp
-    FlattenPass.cpp
-    Utils.cpp
-    InlineAllPass.cpp
     RenameQbitsPass.cpp
     ReverseEdgesPass.cpp
-    CircuitGraphBuilderPass.cpp
-    LayersBuilderPass.cpp
-    LayerBasedOrderingWrapperPass.cpp
-    CNOTLBOWrapperPass.cpp
     SemanticVerifierPass.cpp
-    ArchVerifierPass.cpp
-    Driver.cpp
-    DependencyGraphBuilderPass.cpp
-    CircuitGraph.cpp)
+    Utils.cpp
+    XbitToNumberPass.cpp)

--- a/lib/Transform/IntrinsicGateCostPass.cpp
+++ b/lib/Transform/IntrinsicGateCostPass.cpp
@@ -1,0 +1,48 @@
+#include "enfield/Transform/IntrinsicGateCostPass.h"
+#include "enfield/Support/CommandLine.h"
+
+using namespace efd;
+
+efd::Opt<uint32_t> SwapCost
+("-swap-cost", "Cost of using a swap function.", 7, false);
+efd::Opt<uint32_t> RevCost
+("-rev-cost", "Cost of using a reverse edge.", 4, false);
+efd::Opt<uint32_t> LCXCost
+("-lcx-cost", "Cost of using long cnot gate.", 10, false);
+
+uint8_t IntrinsicGateCostPass::ID = 0;
+
+bool IntrinsicGateCostPass::run(QModule::Ref qmod) {
+    mData = 0;
+
+    const uint8_t _SwapCost = SwapCost.getVal();
+    const uint8_t _RevCost = RevCost.getVal();
+    const uint8_t _LcxCost = LCXCost.getVal();
+
+    for (auto i = qmod->stmt_begin(), e = qmod->stmt_end(); i != e; ++i) {
+        auto node = i->get();
+        auto qOpGen = dynCast<NDQOpGen>(node);
+
+        if (qOpGen != nullptr && qOpGen->isIntrinsic()) {
+            switch (qOpGen->getIntrinsicKind()) {
+                case NDQOpGen::K_INTRINSIC_SWAP:
+                    mData += _SwapCost;
+                    break;
+
+                case NDQOpGen::K_INTRINSIC_REV_CX:
+                    mData += _RevCost;
+                    break;
+
+                case NDQOpGen::K_INTRINSIC_LCX:
+                    mData += _LcxCost;
+                    break;
+            }
+        }
+    }
+
+    return false;
+}
+
+IntrinsicGateCostPass::uRef IntrinsicGateCostPass::Create() {
+    return uRef(new IntrinsicGateCostPass());
+}

--- a/lib/Transform/QModuleQualityEvalPass.cpp
+++ b/lib/Transform/QModuleQualityEvalPass.cpp
@@ -1,0 +1,48 @@
+#include "enfield/Transform/QModuleQualityEvalPass.h"
+#include "enfield/Transform/LayersBuilderPass.h"
+#include "enfield/Transform/QModuleQualityEvalPass.h"
+#include "enfield/Transform/PassCache.h"
+#include "enfield/Support/CommandLine.h"
+#include "enfield/Support/Defs.h"
+
+using namespace efd;
+uint8_t QModuleQualityEvalPass::ID = 0;
+
+QModuleQualityEvalPass::QModuleQualityEvalPass(MapGateUInt gatesW)
+    : mGatesW(gatesW) {}
+
+bool QModuleQualityEvalPass::run(QModule::Ref qmod) {
+     MapGateUInt gatesQ;
+
+    auto &layers = PassCache::Get<LayersBuilderPass>(qmod)->getData();
+
+    for (auto it = qmod->stmt_begin(), e = qmod->stmt_end(); it != e; ++it) {
+        auto node = it->get();
+        auto nodeOp = node->getOperation();
+
+        if (gatesQ.find(nodeOp) == gatesQ.end()) {
+            gatesQ[nodeOp] = 0;
+        }
+
+        ++gatesQ[nodeOp];
+    }
+
+    uint32_t totalWCost = 0;
+    for (auto& pair : gatesQ) {
+        if (mGatesW.find(pair.first) != mGatesW.end()) {
+            totalWCost += (pair.second * mGatesW.at(pair.first));
+        } else {
+            WAR << "No weights for gate: `" << pair.first << "`." << std::endl;
+        }
+    }
+
+    mData.mGates = qmod->getNumberOfStmts();
+    mData.mDepth = layers.size();
+    mData.mWeightedCost = totalWCost;
+
+    return false;
+}
+
+QModuleQualityEvalPass::uRef QModuleQualityEvalPass::Create(MapGateUInt gatesW) {
+    return uRef(new QModuleQualityEvalPass(gatesW));
+}

--- a/tests/ApproxTSFinderTests.cpp
+++ b/tests/ApproxTSFinderTests.cpp
@@ -21,7 +21,8 @@ static const std::string graphstr =
 static Graph::sRef GetGraph() {
     if (graph.get() == nullptr) {
         graph = Graph::ReadString(graphstr);
-        expfinder = ExpTSFinder::Create(graph);
+        expfinder = ExpTSFinder::Create();
+        expfinder->setGraph(graph.get());
     }
 
     return graph;
@@ -29,7 +30,8 @@ static Graph::sRef GetGraph() {
 
 static void CheckSwapSeq(Graph::sRef graph, Assign from, Assign to, bool usingundef) {
     Timer::Start();
-    ApproxTSFinder approxfinder(graph);
+    ApproxTSFinder approxfinder;
+    approxfinder.setGraph(graph.get());
 
     auto approxseq = approxfinder.find(from, to);
 

--- a/tests/BoundedMappingTreeQAllocatorTests.cpp
+++ b/tests/BoundedMappingTreeQAllocatorTests.cpp
@@ -2,12 +2,14 @@
 #include "gtest/gtest.h"
 
 #include "enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h"
+#include "enfield/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.h"
 #include "enfield/Transform/SemanticVerifierPass.h"
 #include "enfield/Transform/ArchVerifierPass.h"
 #include "enfield/Transform/PassCache.h"
 #include "enfield/Arch/ArchGraph.h"
 #include "enfield/Support/RTTI.h"
 #include "enfield/Support/uRefCast.h"
+#include "enfield/Support/ApproxTSFinder.h"
 
 #include <string>
 
@@ -39,6 +41,13 @@ void TestAllocation(const std::string program) {
     auto qmodCopy = qmod->clone();
 
     auto allocator = BoundedMappingTreeQAllocator::Create(g);
+    allocator->setNodeCandidateIterator(SeqNCandidateIterator::Create());\
+    allocator->setChildrenSelector(FirstCandidateSelector::Create());\
+    allocator->setPartialSolutionSelector(FirstCandidateSelector::Create());\
+    allocator->setSwapCostEstimator(GeoDistanceSwapCEstimator::Create());\
+    allocator->setLiveQubitsPreProcessor(GeoNearestLQPProcessor::Create());\
+    allocator->setMapSeqSelector(BestMSSelector::Create());\
+    allocator->setTokenSwapFinder(ApproxTSFinder::Create());\
     allocator->setInlineAll({ "cx" });
     allocator->run(qmod.get());
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,6 +106,9 @@ efd_test (CircuitGraphTests
 efd_test (IntrinsicGateCostPassTests
     EfdAllocator EfdTransform EfdArch EfdAnalysis EfdSupport)
 
+efd_test (QModuleQualityEvalPassTests
+    EfdAllocator EfdTransform EfdArch EfdAnalysis EfdSupport)
+
 # ==-------- Allocator ----------==
 efd_test (DynprogQAllocatorTests
     EfdAllocator EfdTransform EfdArch EfdAnalysis EfdSupport)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,9 @@ efd_test (DependencyGraphBuilderPassTests
 efd_test (CircuitGraphTests
     EfdAllocator EfdTransform EfdArch EfdAnalysis EfdSupport)
 
+efd_test (IntrinsicGateCostPassTests
+    EfdAllocator EfdTransform EfdArch EfdAnalysis EfdSupport)
+
 # ==-------- Allocator ----------==
 efd_test (DynprogQAllocatorTests
     EfdAllocator EfdTransform EfdArch EfdAnalysis EfdSupport)

--- a/tests/IntrinsicGateCostPassTests.cpp
+++ b/tests/IntrinsicGateCostPassTests.cpp
@@ -1,0 +1,201 @@
+
+#include "gtest/gtest.h"
+
+#include "enfield/Transform/IntrinsicGateCostPass.h"
+#include "enfield/Transform/Allocators/QbitAllocator.h"
+#include "enfield/Transform/PassCache.h"
+
+#include <string>
+
+using namespace efd;
+
+void TestBuiltGraph(const std::string& program, uint32_t expectedCost) {
+    auto qmod = QModule::ParseString(program);
+    uint32_t cost = PassCache::Get<IntrinsicGateCostPass>(qmod.get())->getData();
+    EXPECT_EQ(cost, expectedCost);
+}
+
+TEST(IntrinsicGateCostPassTests, NoIntrinsicGate) {
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg r[5];\
+\
+cx r[4], r[0];\
+cx r[4], r[3];\
+cx r[0], r[3];\
+cx r[1], r[3];\
+cx r[1], r[2];\
+cx r[2], r[3];\
+cx r[1], r[4];\
+";
+        TestBuiltGraph(program, 0);
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg r[5];\
+\
+cx r[3], r[1];\
+cx r[3], r[2];\
+cx r[2], r[1];\
+cx r[4], r[0];\
+cx r[4], r[1];\
+cx r[0], r[1];\
+cx r[0], r[3];\
+cx r[3], r[0];\
+cx r[0], r[3];\
+";
+        TestBuiltGraph(program, 0);
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg r[5];\
+\
+cx r[3], r[0];\
+cx r[3], r[1];\
+cx r[1], r[0];\
+cx r[2], r[4];\
+cx r[2], r[0];\
+cx r[4], r[0];\
+cx r[4], r[3];\
+cx r[3], r[4];\
+cx r[4], r[3];\
+";
+        TestBuiltGraph(program, 0);
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg q[5];\
+\
+cx q[0], q[1];\
+cx q[0], q[2];\
+cx q[0], q[3];\
+cx q[0], q[1];\
+cx q[0], q[1];\
+cx q[0], q[2];\
+cx q[0], q[2];\
+";
+        TestBuiltGraph(program, 0);
+    }
+}
+
+TEST(IntrinsicGateCostPassTests, SingleIntrinsicGate) {
+    {
+        const std::string program =
+"\
+qreg q[2];\
+intrinsic_rev_cx__ q[0], q[1];\
+";
+        TestBuiltGraph(program, RevCost.getVal());
+    }
+    {
+        const std::string program =
+"\
+qreg q[2];\
+intrinsic_swap__ q[0], q[1];\
+";
+        TestBuiltGraph(program, SwapCost.getVal());
+    }
+    {
+        const std::string program =
+"\
+qreg q[2];\
+intrinsic_lcx__ q[0], q[1], q[2];\
+";
+        TestBuiltGraph(program, LCXCost.getVal());
+    }
+}
+
+TEST(IntrinsicGateCostPassTests, WholeProgram) {
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg r[5];\
+\
+cx r[4], r[0];\
+intrinsic_rev_cx__ r[4], r[3];\
+cx r[0], r[3];\
+cx r[1], r[3];\
+intrinsic_swap__ r[1], r[2];\
+intrinsic_lcx__ r[2], r[3], r[0];\
+cx r[1], r[4];\
+";
+        TestBuiltGraph(program, RevCost.getVal() + SwapCost.getVal() + LCXCost.getVal());
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg r[5];\
+\
+cx r[3], r[1];\
+cx r[3], r[2];\
+intrinsic_rev_cx__ r[2], r[1];\
+cx r[4], r[0];\
+intrinsic_lcx__ r[0], r[4], r[1];\
+intrinsic_swap__ r[0], r[1];\
+cx r[0], r[3];\
+cx r[3], r[0];\
+cx r[0], r[3];\
+";
+        TestBuiltGraph(program, RevCost.getVal() + SwapCost.getVal() + LCXCost.getVal());
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg r[5];\
+\
+intrinsic_swap__ r[3], r[0];\
+cx r[3], r[1];\
+cx r[1], r[0];\
+cx r[2], r[4];\
+intrinsic_lcx__ r[1], r[2], r[0];\
+cx r[4], r[0];\
+cx r[4], r[3];\
+cx r[3], r[4];\
+intrinsic_rev_cx__ r[4], r[3];\
+";
+        TestBuiltGraph(program, RevCost.getVal() + SwapCost.getVal() + LCXCost.getVal());
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg q[5];\
+\
+cx q[0], q[1];\
+cx q[0], q[2];\
+intrinsic_lcx__ q[2], q[0], q[3];\
+intrinsic_lcx__ q[2], q[0], q[1];\
+cx q[0], q[1];\
+intrinsic_rev_cx__ q[0], q[2];\
+cx q[0], q[2];\
+";
+        TestBuiltGraph(program, (2 * LCXCost.getVal()) + RevCost.getVal());
+    }
+}

--- a/tests/QModuleQualityEvalPassTests.cpp
+++ b/tests/QModuleQualityEvalPassTests.cpp
@@ -1,0 +1,257 @@
+
+#include "gtest/gtest.h"
+
+#include "enfield/Transform/QModuleQualityEvalPass.h"
+#include "enfield/Transform/FlattenPass.h"
+#include "enfield/Transform/InlineAllPass.h"
+#include "enfield/Transform/Allocators/QbitAllocator.h"
+#include "enfield/Transform/PassCache.h"
+
+#include <string>
+
+using namespace efd;
+
+void TestForProgram(const std::string& program, QModuleQuality expected) {
+    auto qmod = QModule::ParseString(program);
+
+    auto inlinePass = InlineAllPass::Create({ "U", "CX" });
+    auto qualityPass = QModuleQualityEvalPass::Create({ {"U", 1}, {"CX", 10} });
+    PassCache::Run<FlattenPass>(qmod.get());
+    PassCache::Run(qmod.get(), inlinePass.get());
+    PassCache::Run(qmod.get(), qualityPass.get());
+
+    auto quality = qualityPass->getData();
+    EXPECT_EQ(quality.mDepth, expected.mDepth);
+    EXPECT_EQ(quality.mGates, expected.mGates);
+    EXPECT_EQ(quality.mWeightedCost, expected.mWeightedCost);
+}
+
+TEST(QModuleQualityEvalPassTests, ZeroCost) {
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+qreg r[5];\
+";
+        TestForProgram(program, QModuleQuality { 0, 0, 0 });
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+qreg r[5];\
+creg c[5];\
+measure r -> c;\
+";
+        TestForProgram(program, QModuleQuality { 1, 5, 0 });
+    }
+}
+
+TEST(QModuleQualityEvalPassTests, OneGate) {
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+qreg r[5];\
+U(pi, pi, pi) r[0];\
+";
+        TestForProgram(program, QModuleQuality { 1, 1, 1 });
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+qreg r[5];\
+creg c[5];\
+CX r[0], r[1];\
+measure r -> c;\
+";
+        TestForProgram(program, QModuleQuality { 2, 6, 10 });
+    }
+}
+
+TEST(QModuleQualityEvalPassTests, OneGenericGate) {
+    {
+        const std::string program =
+"\
+qreg q[2];\
+intrinsic_rev_cx__ q[0], q[1];\
+";
+        TestForProgram(program, QModuleQuality { 3, 5, 14 });
+    }
+    {
+        const std::string program =
+"\
+qreg q[2];\
+intrinsic_swap__ q[0], q[1];\
+";
+        TestForProgram(program, QModuleQuality { 3, 3, 30 });
+    }
+    {
+        const std::string program =
+"\
+qreg q[3];\
+intrinsic_lcx__ q[0], q[1], q[2];\
+";
+        TestForProgram(program, QModuleQuality { 4, 4, 40 });
+    }
+}
+
+TEST(QModuleQualityEvalPassTests, WholeProgram) {
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg r[5];\
+\
+cx r[4], r[0];\
+cx r[4], r[3];\
+cx r[0], r[3];\
+cx r[1], r[3];\
+cx r[1], r[2];\
+cx r[2], r[3];\
+cx r[1], r[4];\
+";
+        TestForProgram(program, QModuleQuality { 6, 7, 70 });
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg r[5];\
+\
+cx r[3], r[1];\
+cx r[3], r[2];\
+cx r[2], r[1];\
+cx r[4], r[0];\
+cx r[4], r[1];\
+cx r[0], r[1];\
+cx r[0], r[3];\
+cx r[3], r[0];\
+cx r[0], r[3];\
+";
+        TestForProgram(program, QModuleQuality { 8, 9, 90 });
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg r[5];\
+\
+cx r[3], r[0];\
+cx r[3], r[1];\
+cx r[1], r[0];\
+cx r[2], r[4];\
+cx r[2], r[0];\
+cx r[4], r[0];\
+cx r[4], r[3];\
+cx r[3], r[4];\
+cx r[4], r[3];\
+";
+        TestForProgram(program, QModuleQuality { 8, 9, 90 });
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg q[5];\
+\
+cx q[0], q[1];\
+cx q[0], q[2];\
+cx q[0], q[3];\
+cx q[0], q[1];\
+cx q[0], q[1];\
+cx q[0], q[2];\
+cx q[0], q[2];\
+";
+        TestForProgram(program, QModuleQuality { 7, 7, 70 });
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg r[5];\
+\
+cx r[4], r[0];\
+intrinsic_rev_cx__ r[4], r[3];\
+cx r[0], r[3];\
+cx r[1], r[3];\
+intrinsic_swap__ r[1], r[2];\
+intrinsic_lcx__ r[2], r[3], r[0];\
+cx r[1], r[4];\
+";
+        TestForProgram(program, QModuleQuality { 12, 16, 124 });
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg r[5];\
+\
+cx r[3], r[1];\
+cx r[3], r[2];\
+intrinsic_rev_cx__ r[2], r[1];\
+cx r[4], r[0];\
+intrinsic_lcx__ r[0], r[4], r[1];\
+intrinsic_swap__ r[0], r[1];\
+cx r[0], r[3];\
+cx r[3], r[0];\
+cx r[0], r[3];\
+";
+        TestForProgram(program, QModuleQuality { 15, 18, 144 });
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg r[5];\
+\
+intrinsic_swap__ r[3], r[0];\
+cx r[3], r[1];\
+cx r[1], r[0];\
+cx r[2], r[4];\
+intrinsic_lcx__ r[1], r[2], r[0];\
+cx r[4], r[0];\
+cx r[4], r[3];\
+cx r[3], r[4];\
+intrinsic_rev_cx__ r[4], r[3];\
+";
+        TestForProgram(program, QModuleQuality { 14, 18, 144 });
+    }
+    {
+        const std::string program =
+"\
+OPENQASM 2.0;\
+include \"qelib1.inc\";\
+\
+qreg q[5];\
+\
+cx q[0], q[1];\
+cx q[0], q[2];\
+intrinsic_lcx__ q[2], q[0], q[3];\
+intrinsic_lcx__ q[2], q[0], q[1];\
+cx q[0], q[1];\
+intrinsic_rev_cx__ q[0], q[2];\
+cx q[0], q[2];\
+";
+        TestForProgram(program, QModuleQuality { 15, 17, 134 });
+    }
+}


### PR DESCRIPTION
Fix #29 .
Because of non-trivial default constructors, it was tricky to parameterize and use the Strategy pattern. One simple solution to it was creating Setter methods for the arguments in the constructor, and any virtual function that needed it was made protected and wrapped in a public function where we would check for whether we did set or not. In other words, we transformed:

```
class A {
    public:
        A(int a) : mA(a) {}
        virtual void foo() = 0;
};
```
into:
```
class A {
    public:
        A() : mA(0) {}
        void foo() { checkASet(); fooImpl(); }
    protected:
        void checkASet() { if (mA == 0) { /* Error not set */ } }
        virtual void fooImpl() = 0;
};
```