### PR TITLE
Simplification of the ApproxTSFinder.

### DIFF
--- a/include/enfield/Arch/Architectures.h
+++ b/include/enfield/Arch/Architectures.h
@@ -15,9 +15,9 @@ namespace efd {
         last
     };
 
-    typedef EnumString<Architecture,
-                       Architecture::first,
-                       Architecture::last> EnumArchitecture;
+    typedef EnumString<Architecture, Architecture::first, Architecture::last>
+            EnumArchitecture;
+    template <> std::vector<std::string> EnumArchitecture::mStrVal;
 
     typedef Registry<ArchGraph::uRef, int, EnumArchitecture> ArchRegistry;
 

--- a/include/enfield/Support/ApproxTSFinder.h
+++ b/include/enfield/Support/ApproxTSFinder.h
@@ -13,6 +13,11 @@ namespace efd {
             typedef ApproxTSFinder* Ref;
             typedef std::unique_ptr<ApproxTSFinder> uRef;
 
+        private:
+            typedef std::vector<uint32_t> GoodVertices;
+            typedef std::vector<std::vector<GoodVertices>> GoodVerticesMatrix;
+            GoodVerticesMatrix mMatrix;
+
         protected:
             void preprocess() override;
             SwapSeq findImpl(const InverseMap& from, const InverseMap& to) override;

--- a/include/enfield/Support/Defs.h
+++ b/include/enfield/Support/Defs.h
@@ -30,7 +30,7 @@ namespace efd {
     std::ostream& InfoLog(std::string file = "", uint32_t line = 0);
 
     /// \brief Aborts reporting the file and the line.
-    void Abort(std::string file = "", uint32_t line = 0);
+    void Abort [[noreturn]] (std::string file = "", uint32_t line = 0);
 }
 
 #ifndef EFD_MESSAGE_LOG

--- a/include/enfield/Support/Graph.h
+++ b/include/enfield/Support/Graph.h
@@ -38,6 +38,7 @@ namespace efd {
             virtual std::string edgeToString(uint32_t i, uint32_t j, std::string op) const;
 
         public:
+            virtual ~Graph() = default;
             Graph(uint32_t n, Type ty = Undirected);
 
             /// \brief Return the degree entering the vertex \p i.

--- a/include/enfield/Support/PathFinder.h
+++ b/include/enfield/Support/PathFinder.h
@@ -10,6 +10,8 @@ namespace efd {
             typedef PathFinder* Ref;
             typedef std::shared_ptr<PathFinder> sRef;
 
+            virtual ~PathFinder() = default;
+
             /// \brief Searches for a path from \p u to \p v in the graph \p g.
             ///
             /// This function is to be implemented by the concrete classes. It should

--- a/include/enfield/Support/SIFinder.h
+++ b/include/enfield/Support/SIFinder.h
@@ -21,6 +21,8 @@ namespace efd {
                 Mapping m;
             };
 
+            virtual ~SIFinder() = default;
+
             /// \brief Returns a valid matching of \p h in \p g.
             ///
             /// Note that this is not necessairly an exact match (exact 

--- a/include/enfield/Support/SimplifiedApproxTSFinder.h
+++ b/include/enfield/Support/SimplifiedApproxTSFinder.h
@@ -1,0 +1,31 @@
+#ifndef __EFD_SIMPLIFIED_APPROX_TS_FINDER_H__
+#define __EFD_SIMPLIFIED_APPROX_TS_FINDER_H__
+
+#include "enfield/Support/TokenSwapFinder.h"
+
+namespace efd {
+    /// \brief Simplified 4-Approximative polynomial algorithm.
+    ///
+    /// Miltzow et al.
+    /// DOI: 10.4230/LIPIcs.ESA.2016.66
+    class SimplifiedApproxTSFinder : public TokenSwapFinder {
+        public:
+            typedef SimplifiedApproxTSFinder* Ref;
+            typedef std::unique_ptr<SimplifiedApproxTSFinder> uRef;
+
+        private:
+            typedef std::vector<uint32_t> GoodVertices;
+            typedef std::vector<std::vector<GoodVertices>> GoodVerticesMatrix;
+            GoodVerticesMatrix mMatrix;
+
+        protected:
+            void preprocess() override;
+            SwapSeq findImpl(const InverseMap& from, const InverseMap& to) override;
+
+        public:
+            /// \brief Creates an instance of this class.
+            static uRef Create();
+    };
+}
+
+#endif

--- a/include/enfield/Support/TokenSwapFinder.h
+++ b/include/enfield/Support/TokenSwapFinder.h
@@ -20,6 +20,8 @@ namespace efd {
             virtual SwapSeq findImpl(const InverseMap& from, const InverseMap& to) = 0;
 
         public:
+            virtual ~TokenSwapFinder() = default;
+
             /// \brief Sets the `Graph`.
             void setGraph(Graph::Ref graph);
             /// \brief Finds a swap sequence to reach \p to from \p from.

--- a/include/enfield/Transform/Allocators/Allocators.def
+++ b/include/enfield/Transform/Allocators/Allocators.def
@@ -15,6 +15,20 @@ EFD_ALLOCATOR_BMT(ibmt, CircuitCandidatesGenerator,
                         GeoNearestLQPProcessor,
                         BestNMSSelector,
                         ApproxTSFinder)
+EFD_ALLOCATOR_BMT(simplified_bmt, SeqNCandidatesGenerator,
+                                  FirstCandidateSelector,
+                                  FirstCandidateSelector,
+                                  GeoDistanceSwapCEstimator,
+                                  GeoNearestLQPProcessor,
+                                  BestNMSSelector,
+                                  SimplifiedApproxTSFinder)
+EFD_ALLOCATOR_BMT(simplified_ibmt, CircuitCandidatesGenerator,
+                                   WeightedRouletteCandidateSelector,
+                                   WeightedRouletteCandidateSelector,
+                                   GeoDistanceSwapCEstimator,
+                                   GeoNearestLQPProcessor,
+                                   BestNMSSelector,
+                                   SimplifiedApproxTSFinder)
 EFD_ALLOCATOR_SIMPLE(wpm, WeightedSIMappingFinder, PathGuidedSolBuilder)
 EFD_ALLOCATOR_SIMPLE(random, RandomMappingFinder, PathGuidedSolBuilder)
 EFD_ALLOCATOR_SIMPLE(qubiter, IdentityMappingFinder, QbitterSolBuilder)

--- a/include/enfield/Transform/Allocators/Allocators.h
+++ b/include/enfield/Transform/Allocators/Allocators.h
@@ -24,6 +24,7 @@ namespace efd {
 
     typedef EnumString<Allocator, Allocator::first, Allocator::last>
             EnumAllocator;
+    template <> std::vector<std::string> EnumAllocator::mStrVal;
 
     typedef Registry<QbitAllocator::uRef, ArchGraph::sRef, EnumAllocator>
             AllocatorRegistry;

--- a/include/enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h
+++ b/include/enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h
@@ -73,6 +73,7 @@ namespace efd {
         typedef NodeCandidatesGenerator* Ref;
         typedef std::unique_ptr<NodeCandidatesGenerator> uRef;
 
+        virtual ~NodeCandidatesGenerator() = default;
         NodeCandidatesGenerator();
 
         /// \brief Sets the `QModule` to be iterated.
@@ -103,6 +104,7 @@ namespace efd {
     struct CandidateSelector {
         typedef CandidateSelector* Ref;
         typedef std::unique_ptr<CandidateSelector> uRef;
+        virtual ~CandidateSelector() = default;
         /// \brief Selects \em maxCandidates from \em candidates.
         virtual bmt::MCandidateVector select(uint32_t maxCandidates,
                                             const bmt::MCandidateVector& candidates) = 0;
@@ -113,6 +115,7 @@ namespace efd {
         typedef SwapCostEstimator* Ref;
         typedef std::unique_ptr<SwapCostEstimator> uRef;
 
+        virtual ~SwapCostEstimator() = default;
         SwapCostEstimator();
 
         /// \brief Sets the `Graph`.
@@ -134,6 +137,7 @@ namespace efd {
     struct LiveQubitsPreProcessor {
         typedef LiveQubitsPreProcessor* Ref;
         typedef std::unique_ptr<LiveQubitsPreProcessor> uRef;
+        virtual ~LiveQubitsPreProcessor() = default;
         /// \brief Processes `Mapping` \em toM, based on the graph \em g and on the
         /// last `Mapping` \em fromM.
         virtual void process(const Graph::Ref g, Mapping& fromM, Mapping& toM) = 0;
@@ -143,6 +147,7 @@ namespace efd {
     struct MapSeqSelector {
         typedef MapSeqSelector* Ref;
         typedef std::unique_ptr<MapSeqSelector> uRef;
+        virtual ~MapSeqSelector() = default;
         /// \brief Returns a vector with the line indexes chosen to be tracebacked.
         virtual bmt::Vector select(const bmt::TIMatrix& mem) = 0;
     };

--- a/include/enfield/Transform/Allocators/SimpleQAllocator.h
+++ b/include/enfield/Transform/Allocators/SimpleQAllocator.h
@@ -13,6 +13,8 @@ namespace efd {
             typedef MappingFinder* Ref;
             typedef std::shared_ptr<MappingFinder> sRef;
 
+            virtual ~MappingFinder() = default;
+
             /// \brief Returns a mapping generated from a set of dependencies.
             virtual Mapping find(ArchGraph::Ref g, DepsVector& deps) = 0;
     };
@@ -33,6 +35,8 @@ namespace efd {
             typedef std::shared_ptr<SolutionBuilder> sRef;
 
         public:
+            virtual ~SolutionBuilder() = default;
+
             SolutionBuilder() {
                 set(SolutionBuilderOptions::ImproveInitial);
                 set(SolutionBuilderOptions::KeepStats);

--- a/include/enfield/Transform/ErrorRateCalculationPass.h
+++ b/include/enfield/Transform/ErrorRateCalculationPass.h
@@ -1,0 +1,37 @@
+#ifndef __EFD_ERROR_RATE_CALCULATION_PASS_H__
+#define __EFD_ERROR_RATE_CALCULATION_PASS_H__
+
+#include "enfield/Transform/QModule.h"
+#include "enfield/Transform/Pass.h"
+#include "enfield/Arch/ArchGraph.h"
+
+#include <map>
+
+namespace efd {
+    /// \brief Calculates the approximate error rate of a program.
+    class ErrorRateCalculationPass : public PassT<double> {
+        public:
+            typedef ErrorRateCalculationPass* Ref;
+            typedef std::unique_ptr<ErrorRateCalculationPass> uRef;
+            typedef std::shared_ptr<ErrorRateCalculationPass> sRef;
+
+            static uint8_t ID;
+
+        private:
+            ArchGraph::sRef mArchGraph;
+
+        public:
+            ErrorRateCalculationPass(ArchGraph::sRef arch = nullptr);
+
+            /// \brief Sets the \em ArchGraph that this pass should use for calculating
+            /// the error rate.
+            void setArchGraph(ArchGraph::sRef arch);
+
+            bool run(QModule::Ref qmod) override;
+
+            /// \brief Returns a new instance of this class.
+            static uRef Create(ArchGraph::sRef arch = nullptr);
+    };
+};
+
+#endif

--- a/include/enfield/Transform/Pass.h
+++ b/include/enfield/Transform/Pass.h
@@ -26,6 +26,8 @@ namespace efd {
             Pass(Kind k);
 
         public:
+            virtual ~Pass() = default;
+
             /// \brief Runs the pass in the given QModule and returns true if it has
             /// modified \p qmod.
             virtual bool run(QModule* qmod) = 0;

--- a/include/enfield/Transform/Utils.h
+++ b/include/enfield/Transform/Utils.h
@@ -9,8 +9,12 @@
 namespace efd {
     typedef std::map<std::string, uint32_t> GateWeightMap;
     typedef std::vector<std::string> GateNameVector;
+    typedef std::pair<NDIfStmt::Ref, NDQOp::Ref> StatementPair;
+
     /// \brief Extracts only the gate names to a separate vector.
     GateNameVector ExtractGateNames(const GateWeightMap& map);
+    /// \brief Breakdowns the \p node into \em NDIfStmt and \em NDQOp pair.
+    StatementPair GetStatementPair(const Node::Ref node);
 
     /// \brief If found, inlines the gate that \p qop calls.
     void InlineGate(QModule::Ref qmod, NDQOp::Ref qop);

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -1,13 +1,14 @@
 add_library (EfdSupport
-    CommandLine.cpp
-    WrapperVal.cpp
-    Graph.cpp
-    BFSPathFinder.cpp
-    Timer.cpp
-    Stats.cpp
-    ExpTSFinder.cpp
     ApproxTSFinder.cpp
+    BFSPathFinder.cpp
+    CommandLine.cpp
     Defs.cpp
-    TokenSwapFinder.cpp
+    ExpTSFinder.cpp
+    Graph.cpp
     JsonParser.cpp
-    WeightedGraph.cpp)
+    Stats.cpp
+    SimplifiedApproxTSFinder.cpp
+    Timer.cpp
+    TokenSwapFinder.cpp
+    WeightedGraph.cpp
+    WrapperVal.cpp)

--- a/lib/Support/SimplifiedApproxTSFinder.cpp
+++ b/lib/Support/SimplifiedApproxTSFinder.cpp
@@ -1,0 +1,226 @@
+#include "enfield/Support/SimplifiedApproxTSFinder.h"
+#include "enfield/Support/WeightedGraph.h"
+#include "enfield/Support/Defs.h"
+
+#include <limits>
+#include <queue>
+#include <stack>
+#include <set>
+#include <map>
+
+// White, gray and black are the usual dfs guys.
+// Silver is for marking when it is already in the stack
+// (for iterative versions).
+static const uint32_t _white  = 0;
+static const uint32_t _silver = 1;
+static const uint32_t _gray   = 2;
+static const uint32_t _black  = 3;
+
+static std::vector<uint32_t> findCycleDFS(uint32_t src,
+                                          std::vector<std::vector<uint32_t>>& adj) {
+    std::vector<uint32_t> color(adj.size(), _white);
+    std::vector<uint32_t> pi(adj.size(), efd::_undef);
+    std::stack<uint32_t> stack;
+
+    stack.push(src);
+    color[src] = _silver;
+
+    uint32_t from, to;
+    bool cyclefound = false;
+
+    // The color "hierarchy" goes:
+    // white -> silver -> gray -> black
+    while (!cyclefound && !stack.empty()) {
+        uint32_t u = stack.top();
+        if (color[u] == _gray) { color[u] = _black; stack.pop(); continue; }
+        color[u] = _gray;
+
+        for (auto v : adj[u]) {
+            if (color[v] == _white) {
+                pi[v] = u;
+                color[v] = _silver;
+                stack.push(v);
+            } else if (color[v] == _gray) {
+                from = u; to = v;
+                cyclefound = true;
+                break;
+            }
+        }
+    }
+
+    std::vector<uint32_t> cycle;
+
+    if (cyclefound) {
+        cycle.push_back(from);
+
+        do {
+            from = pi[from];
+            cycle.push_back(from);
+        } while (from != to);
+    }
+
+    return cycle;
+}
+
+static std::vector<std::vector<uint32_t>>
+findGoodVerticesBFS(efd::Graph::Ref graph, uint32_t src) {
+    uint32_t size = graph->size();
+    const uint32_t inf = std::numeric_limits<uint32_t>::max();
+    // List of good vertices used to reach the 'i'-th vertex.
+    // We say 'u' is a good vertex of 'v' iff the path 'src -> u -> v' results in the
+    // smallest path from 'src' to 'v'.
+    std::vector<std::vector<uint8_t>> goodvlist(size, std::vector<uint8_t>(size, false));
+    // Distance from the source.
+    std::vector<uint32_t> d(size, inf);
+    std::queue<uint32_t> q;
+
+    d[src] = 0;
+    q.push(src);
+    // Complexity: O(E(G) * V(G))
+    while (!q.empty()) {
+        uint32_t u = q.front();
+        q.pop();
+
+        // Complexity: O(Adj(u) * V(G))
+        for (auto v : graph->adj(u)) {
+            // If it is our first time visiting 'v' or the distance of 'src -> u -> v'
+            // is equal the best distance of 'v' ('d[v]'), then 'u' is a good vertex of
+            // 'v'.
+            // Complexity: O(1)
+            if (d[v] == inf) {
+                q.push(v);
+                d[v] = d[u] + 1;
+            }
+
+            if (d[v] == d[u] + 1) {
+                goodvlist[v][v] = true;
+
+                // Every good vertex of 'u' is also a good vertex of 'v'.
+                // So, goodvlist[v] should be the union of goodvlist[v] and goodvlist[u],
+                // since we can have multiple shortest paths reaching 'v'.
+                // Complexity: O(V(G))
+                for (uint32_t i = 0; i < size; ++i) {
+                    goodvlist[v][i] |= goodvlist[u][i];
+                }
+            }
+        }
+    }
+
+    std::vector<std::vector<uint32_t>> goodv(size, std::vector<uint32_t>());
+
+    // Complexity: O(V(G) * V(G))
+    for (uint32_t u = 0; u < size; ++u) {
+        for (auto v : graph->adj(src)) {
+            if (goodvlist[u][v])
+                goodv[u].push_back(v);
+        }
+    }
+
+    return goodv;
+}
+
+efd::SwapSeq efd::SimplifiedApproxTSFinder::findImpl(const InverseMap& from, const InverseMap& to) {
+    auto fromInv = from;
+    auto toInv = to;
+
+    uint32_t size = mG->size();
+    std::vector<std::vector<uint32_t>> gprime(size, std::vector<uint32_t>());
+    std::vector<bool> inplace(size, true);
+    SwapSeq swapseq;
+
+    // Constructing the inverse for 'to' -----------------------
+    Mapping toMap(size, _undef);
+    for (uint32_t i = 0; i < size; ++i) {
+        if (toInv[i] != _undef)
+            toMap[toInv[i]] = i;
+    }
+    // ---------------------------------------------------------
+
+    // Initializing data ---------------------------------------
+    // 1. Checking which vertices are inplace.
+    for (uint32_t i = 0; i < size; ++i)
+        if (fromInv[i] == _undef) inplace[i] = true;
+        else inplace[i] = fromInv[i] == toInv[i];
+
+    // 2. Constructing the graph with the good neighbors.
+    for (uint32_t i = 0; i < size; ++i) {
+        if (fromInv[i] != _undef)
+            gprime[i] = mMatrix[i][toMap[fromInv[i]]];
+    }
+    // ---------------------------------------------------------
+
+    // Main Loop -----------------------------------------------
+    do {
+        std::vector<uint32_t> swappath;
+
+        // 1. Trying to find a 'happy chain'
+        for (uint32_t i = 0; i < size; ++i)
+            if (!inplace[i]) {
+                swappath = findCycleDFS(i, gprime);
+                if (!swappath.empty()) break;
+            }
+
+        // 2. If we failed, we want a unhappy swap
+        if (swappath.empty()) {
+            // We search for an edge (u, v), such that 'u' has a label that
+            // is out of place, and 'v' has a label in place.
+            for (uint32_t u = 0; u < size; ++u) {
+                if (!inplace[u]) {
+                    bool found = false;
+
+                    for (auto v : gprime[u])
+                        if (inplace[v]) {
+                            found = true;
+                            swappath = { u, v };
+                            break;
+                        }
+
+                    if (found) break;
+                }
+            }
+        }
+
+        // 3. Swap what we found
+        if (!swappath.empty()) {
+            for (uint32_t i = 1, e = swappath.size(); i < e; ++i) {
+                auto u = swappath[i-1], v = swappath[i];
+                swapseq.push_back({ u, v });
+                std::swap(fromInv[u], fromInv[v]);
+            }
+
+            // Updating those vertices that were swapped.
+            // The others neither were magically put into place nor changed 'their mind'
+            // about where to go (which are good neighbors).
+            for (uint32_t i = 0, e = swappath.size(); i < e; ++i) {
+                // Updating vertex u.
+                auto u = swappath[i];
+
+                if (fromInv[u] == _undef) {
+                    inplace[u] = true;
+                    gprime[u].clear();
+                    continue;
+                }
+
+                if (fromInv[u] == toInv[u]) inplace[u] = true;
+                else inplace[u] = false;
+
+                gprime[u] = mMatrix[u][toMap[fromInv[u]]];
+            }
+        } else {
+            break;
+        }
+    } while (true);
+    // ---------------------------------------------------------
+
+    return swapseq;
+}
+
+void efd::SimplifiedApproxTSFinder::preprocess() {
+    for (uint32_t u = 0; u < mG->size(); ++u) {
+        mMatrix.push_back(findGoodVerticesBFS(mG, u));
+    }
+}
+
+efd::SimplifiedApproxTSFinder::uRef efd::SimplifiedApproxTSFinder::Create() {
+    return uRef(new SimplifiedApproxTSFinder());
+}

--- a/lib/Transform/Allocators/Allocators.cpp
+++ b/lib/Transform/Allocators/Allocators.cpp
@@ -8,6 +8,7 @@
 #include "enfield/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.h"
 #include "enfield/Transform/Allocators/BMT/ImprovedBMTQAllocatorImpl.h"
 #include "enfield/Support/ApproxTSFinder.h"
+#include "enfield/Support/SimplifiedApproxTSFinder.h"
 
 #include "enfield/Transform/Allocators/Simple/WeightedSIMappingFinder.h"
 #include "enfield/Transform/Allocators/Simple/RandomMappingFinder.h"

--- a/lib/Transform/CMakeLists.txt
+++ b/lib/Transform/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library (EfdTransform
     DependencyBuilderPass.cpp
     DependencyGraphBuilderPass.cpp
     Driver.cpp
+    ErrorRateCalculationPass.cpp
     FlattenPass.cpp
     InlineAllPass.cpp
     LayersBuilderPass.cpp

--- a/lib/Transform/ErrorRateCalculationPass.cpp
+++ b/lib/Transform/ErrorRateCalculationPass.cpp
@@ -1,0 +1,36 @@
+#include "enfield/Transform/ErrorRateCalculationPass.h"
+#include "enfield/Transform/Utils.h"
+
+using namespace efd;
+
+uint8_t efd::ErrorRateCalculationPass::ID = 0;
+
+ErrorRateCalculationPass::ErrorRateCalculationPass(ArchGraph::sRef arch) : mArchGraph(arch) {}
+
+bool ErrorRateCalculationPass::run(QModule::Ref qmod) {
+    if (mArchGraph.get() == nullptr) {
+        ERR << "mArchGraph not defined for `ErrorRateCalculationPass`." << std::endl;
+        EFD_ABORT();
+    }
+
+    double result = 1;
+
+    for (auto it = qmod->stmt_begin(), end = qmod->stmt_end(); it != end; ++it) {
+        auto qopNode = GetStatementPair(it->get()).second;
+
+        if (IsCNOTGateCall(qopNode)) {
+            auto qargs = qopNode->getQArgs();
+            uint32_t u = mArchGraph->getUId(qargs->getChild(0)->toString(false));
+            uint32_t v = mArchGraph->getUId(qargs->getChild(1)->toString(false));
+            result = result * mArchGraph->getW(u, v);
+        }
+    }
+
+    mData = 1 - result;
+
+    return false;
+}
+
+ErrorRateCalculationPass::uRef ErrorRateCalculationPass::Create(ArchGraph::sRef arch) {
+    return uRef(new ErrorRateCalculationPass(arch));
+}

--- a/lib/Transform/QModuleQualityEvalPass.cpp
+++ b/lib/Transform/QModuleQualityEvalPass.cpp
@@ -1,7 +1,7 @@
 #include "enfield/Transform/QModuleQualityEvalPass.h"
 #include "enfield/Transform/LayersBuilderPass.h"
-#include "enfield/Transform/QModuleQualityEvalPass.h"
 #include "enfield/Transform/PassCache.h"
+#include "enfield/Transform/Utils.h"
 #include "enfield/Support/CommandLine.h"
 #include "enfield/Support/Defs.h"
 
@@ -17,8 +17,8 @@ bool QModuleQualityEvalPass::run(QModule::Ref qmod) {
     auto &layers = PassCache::Get<LayersBuilderPass>(qmod)->getData();
 
     for (auto it = qmod->stmt_begin(), e = qmod->stmt_end(); it != e; ++it) {
-        auto node = it->get();
-        auto nodeOp = node->getOperation();
+        auto qopNode = GetStatementPair(it->get()).second;
+        auto nodeOp = qopNode->getOperation();
 
         if (gatesQ.find(nodeOp) == gatesQ.end()) {
             gatesQ[nodeOp] = 0;

--- a/lib/Transform/Utils.cpp
+++ b/lib/Transform/Utils.cpp
@@ -20,6 +20,24 @@ GateNameVector efd::ExtractGateNames(const GateWeightMap& map) {
     return vector;
 }
 
+StatementPair efd::GetStatementPair(const Node::Ref node) {
+    StatementPair pair { nullptr, nullptr };
+    pair.second = dynCast<NDQOp>(node);
+
+    if (pair.second == nullptr) {
+        pair.first = dynCast<NDIfStmt>(node);
+
+        if (pair.first == nullptr) {
+            ERR << "Unknown instruction type: `" << node->toString(false) << "`." << std::endl;
+            EFD_ABORT();
+        }
+
+        pair.second = pair.first->getQOp();
+    }
+
+    return pair;
+}
+
 // ==--------------- Intrinsic Gates ---------------==
 static std::vector<NDGateSign::uRef> IntrinsicGates;
 static const std::string IntrinsicGatesStr =

--- a/tests/ApproxTSFinderTests.cpp
+++ b/tests/ApproxTSFinderTests.cpp
@@ -5,9 +5,14 @@
 
 using namespace efd;
 
-static ExpTSFinder::uRef expfinder;
-static Graph::sRef graph;
-static const std::string graphstr =
+static ExpTSFinder::uRef expFinder;
+static ApproxTSFinder::uRef approxFinder5V;
+static ApproxTSFinder::uRef approxFinder16V;
+
+static Graph::sRef graph5V;
+static Graph::sRef graph16V;
+
+static const std::string graph5VStr =
 "{\
     \"vertices\": 5,\
     \"type\": \"Undirected\",\
@@ -19,185 +24,7 @@ static const std::string graphstr =
         [ {\"v\": 2} ]\
     ]\
 }";
-
-static Graph::sRef GetGraph() {
-    if (graph.get() == nullptr) {
-        graph = JsonParser<efd::Graph>::ParseString(graphstr);
-        expfinder = ExpTSFinder::Create();
-        expfinder->setGraph(graph.get());
-    }
-
-    return graph;
-}
-
-static void CheckSwapSeq(Graph::sRef graph, InverseMap from, InverseMap to, bool usingundef) {
-    Timer::Start();
-    ApproxTSFinder approxfinder;
-    approxfinder.setGraph(graph.get());
-
-    auto approxseq = approxfinder.find(from, to);
-
-    if (!usingundef) {
-        auto expseq = expfinder->find(from, to);
-
-        ASSERT_TRUE(approxseq.size() <= 4 * expseq.size());
-
-        if (approxseq.size() != expseq.size()) {
-            std::cerr << "4-Approx: " << approxseq.size() << std::endl;
-            std::cerr << "Exp: " << expseq.size() << std::endl;
-        }
-    } else {
-        std::cerr << "4-Approx: " << approxseq.size() << std::endl;
-    }
-
-    if (!approxseq.empty()) {
-        for (auto swap : approxseq)
-            std::swap(from[swap.u], from[swap.v]);
-    }
-
-    ASSERT_EQ(from, to);
-    std::cerr << "time: " << Timer::Stop<std::chrono::microseconds>() << std::endl;
-}
-
-static void CheckSwapSeqWrapper(InverseMap from, InverseMap to, bool usingundef = false) {
-    CheckSwapSeq(GetGraph(), from, to, usingundef);
-}
-
-TEST(ApproxTSFinderTests, NoSwapTest) {
-    {
-        InverseMap from { 0, 1, 2, 3, 4 };
-        InverseMap to   { 0, 1, 2, 3, 4 };
-        CheckSwapSeqWrapper(from, to);
-    }
-
-    {
-        InverseMap from { 4, 3, 2, 1, 0 };
-        InverseMap to   { 4, 3, 2, 1, 0 };
-        CheckSwapSeqWrapper(from, to);
-    }
-}
-
-TEST(ApproxTSFinderTests, SimpleSwapTest) {
-    {
-        InverseMap from { 0, 1, 2, 4, 3 };
-        InverseMap to   { 0, 1, 2, 3, 4 };
-        CheckSwapSeqWrapper(from, to);
-    }
-
-    {
-        InverseMap from { 0, 1, 2, 3, 4 };
-        InverseMap to   { 0, 1, 2, 4, 3 };
-        CheckSwapSeqWrapper(from, to);
-    }
-
-    {
-        InverseMap from { 4, 3, 0, 1, 2 };
-        InverseMap to   { 4, 3, 2, 1, 0 };
-        CheckSwapSeqWrapper(from, to);
-    }
-
-    {
-        InverseMap from { 4, 3, 2, 1, 0 };
-        InverseMap to   { 4, 3, 0, 1, 2 };
-        CheckSwapSeqWrapper(from, to);
-    }
-}
-
-TEST(ApproxTSFinderTests, ComplexSwapTest) {
-    {
-        InverseMap from { 0, 1, 2, 4, 3 };
-        InverseMap to   { 4, 3, 2, 1, 0 };
-        CheckSwapSeqWrapper(from, to);
-    }
-
-    {
-        InverseMap from { 4, 3, 0, 1, 2 };
-        InverseMap to   { 0, 1, 2, 4, 3 };
-        CheckSwapSeqWrapper(from, to);
-    }
-
-    {
-        InverseMap from { 3, 4, 2, 0, 1 };
-        InverseMap to   { 0, 1, 2, 3, 4 };
-        CheckSwapSeqWrapper(from, to);
-    }
-
-    {
-        InverseMap from { 3, 1, 2, 0, 4 };
-        InverseMap to   { 0, 1, 2, 3, 4 };
-        CheckSwapSeqWrapper(from, to);
-    }
-}
-
-TEST(ApproxTSFinderTests, AllPermutationsTest) {
-    std::vector<InverseMap> invs;
-    InverseMap perm { 0, 1, 2, 3, 4 };
-
-    do {
-        invs.push_back(perm);
-    } while (std::next_permutation(perm.begin(), perm.end()));
-
-    ASSERT_EQ(invs.size(), (uint32_t) 120);
-
-    uint32_t x = 0;
-    for (uint32_t i = 0, e = invs.size(); i < e; ++i)
-        for (uint32_t j = 0; j < e; ++j, ++x)
-            CheckSwapSeqWrapper(invs[i], invs[j]);
-}
-
-// Using undef
-TEST(ApproxTSFinderTests, UndefNoSwapTest) {
-    {
-        InverseMap from { 0, _undef, 2, 4, _undef };
-        InverseMap to   { 0, _undef, 2, 4, _undef };
-        CheckSwapSeqWrapper(from, to, true);
-    }
-
-    {
-        InverseMap from { _undef, _undef, _undef, _undef, _undef };
-        InverseMap to   { _undef, _undef, _undef, _undef, _undef };
-        CheckSwapSeqWrapper(from, to, true);
-    }
-}
-
-TEST(ApproxTSFinderTests, UndefOneSwapTest) {
-    {
-        InverseMap from { 0, _undef, 2, 4, _undef };
-        InverseMap to   { 0, _undef, 4, 2, _undef };
-        CheckSwapSeqWrapper(from, to, true);
-    }
-
-    {
-        InverseMap from { 1, _undef, 0, _undef, _undef };
-        InverseMap to   { 0, _undef, 1, _undef, _undef };
-        CheckSwapSeqWrapper(from, to, true);
-    }
-}
-
-TEST(ApproxTSFinderTests, UndefComplexSwapTest) {
-    {
-        InverseMap from { 0, _undef, 2, 4, _undef };
-        InverseMap to   { _undef, _undef, 4, 2, 0 };
-        CheckSwapSeqWrapper(from, to, true);
-    }
-
-    {
-        InverseMap from { 1, _undef, 0, _undef, _undef };
-        InverseMap to   { _undef, _undef, 1, _undef, 0 };
-        CheckSwapSeqWrapper(from, to, true);
-    }
-
-    {
-        InverseMap from { 1, _undef, 0, 4, 3 };
-        InverseMap to   { 4, 1, 0, 3, _undef };
-        CheckSwapSeqWrapper(from, to, true);
-    }
-}
-
-TEST(ApproxTSFinderTests, Undef16QComplexSwapTest) {
-    Graph::sRef graph;
-
-    const std::string graphstr =
+static const std::string graph16VStr =
 "{\
     \"vertices\": 16,\
     \"type\": \"Undirected\",\
@@ -220,9 +47,196 @@ TEST(ApproxTSFinderTests, Undef16QComplexSwapTest) {
         [ {\"v\": 0}, {\"v\": 14} ]\
     ]\
 }";
-    
-    graph = JsonParser<efd::Graph>::ParseString(graphstr);
 
+struct TestEnvironment : public ::testing::Environment {
+    void SetUp() override {
+        graph5V = JsonParser<efd::Graph>::ParseString(graph5VStr);
+        graph16V = JsonParser<efd::Graph>::ParseString(graph16VStr);
+
+        expFinder = ExpTSFinder::Create();
+        approxFinder5V = ApproxTSFinder::Create();
+        approxFinder16V = ApproxTSFinder::Create();
+
+        expFinder->setGraph(graph5V.get());
+        approxFinder5V->setGraph(graph5V.get());
+        approxFinder16V->setGraph(graph16V.get());
+    }
+};
+
+::testing::Environment* const env =
+::testing::AddGlobalTestEnvironment(new TestEnvironment());
+
+static void CheckSwapSeq(ApproxTSFinder::Ref approx,
+                         const InverseMap& from,
+                         const InverseMap& to,
+                         bool hasUndef) {
+    Timer::Start();
+
+    auto approxseq = approx->find(from, to);
+
+    if (!hasUndef) {
+        auto expseq = expFinder->find(from, to);
+
+        ASSERT_TRUE(approxseq.size() <= 4 * expseq.size());
+
+        if (approxseq.size() != expseq.size()) {
+            std::cerr << "4-Approx: " << approxseq.size() << std::endl;
+            std::cerr << "Exp: " << expseq.size() << std::endl;
+        }
+    } else {
+        std::cerr << "4-Approx: " << approxseq.size() << std::endl;
+    }
+
+    auto _from = from;
+    if (!approxseq.empty()) {
+        for (auto swap : approxseq)
+            std::swap(_from[swap.u], _from[swap.v]);
+    }
+
+    ASSERT_EQ(_from, to);
+    std::cerr << "time: " << Timer::Stop<std::chrono::microseconds>() << std::endl;
+}
+
+static void CheckSwapSeq5V(const InverseMap& from, const InverseMap& to, bool hasUndef = false) {
+    CheckSwapSeq(approxFinder5V.get(), from, to, hasUndef);
+}
+
+static void CheckSwapSeq16V(const InverseMap& from, const InverseMap& to, bool hasUndef = true) {
+    CheckSwapSeq(approxFinder16V.get(), from, to, hasUndef);
+}
+
+TEST(ApproxTSFinderTests, NoSwapTest) {
+    {
+        InverseMap from { 0, 1, 2, 3, 4 };
+        InverseMap to   { 0, 1, 2, 3, 4 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 4, 3, 2, 1, 0 };
+        InverseMap to   { 4, 3, 2, 1, 0 };
+        CheckSwapSeq5V(from, to);
+    }
+}
+
+TEST(ApproxTSFinderTests, SimpleSwapTest) {
+    {
+        InverseMap from { 0, 1, 2, 4, 3 };
+        InverseMap to   { 0, 1, 2, 3, 4 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 0, 1, 2, 3, 4 };
+        InverseMap to   { 0, 1, 2, 4, 3 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 4, 3, 0, 1, 2 };
+        InverseMap to   { 4, 3, 2, 1, 0 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 4, 3, 2, 1, 0 };
+        InverseMap to   { 4, 3, 0, 1, 2 };
+        CheckSwapSeq5V(from, to);
+    }
+}
+
+TEST(ApproxTSFinderTests, ComplexSwapTest) {
+    {
+        InverseMap from { 0, 1, 2, 4, 3 };
+        InverseMap to   { 4, 3, 2, 1, 0 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 4, 3, 0, 1, 2 };
+        InverseMap to   { 0, 1, 2, 4, 3 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 3, 4, 2, 0, 1 };
+        InverseMap to   { 0, 1, 2, 3, 4 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 3, 1, 2, 0, 4 };
+        InverseMap to   { 0, 1, 2, 3, 4 };
+        CheckSwapSeq5V(from, to);
+    }
+}
+
+TEST(ApproxTSFinderTests, AllPermutationsTest) {
+    std::vector<InverseMap> invs;
+    InverseMap perm { 0, 1, 2, 3, 4 };
+
+    do {
+        invs.push_back(perm);
+    } while (std::next_permutation(perm.begin(), perm.end()));
+
+    ASSERT_EQ(invs.size(), (uint32_t) 120);
+
+    uint32_t x = 0;
+    for (uint32_t i = 0, e = invs.size(); i < e; ++i)
+        for (uint32_t j = 0; j < e; ++j, ++x)
+            CheckSwapSeq5V(invs[i], invs[j]);
+}
+
+// Using undef
+TEST(ApproxTSFinderTests, UndefNoSwapTest) {
+    {
+        InverseMap from { 0, _undef, 2, 4, _undef };
+        InverseMap to   { 0, _undef, 2, 4, _undef };
+        CheckSwapSeq5V(from, to, true);
+    }
+
+    {
+        InverseMap from { _undef, _undef, _undef, _undef, _undef };
+        InverseMap to   { _undef, _undef, _undef, _undef, _undef };
+        CheckSwapSeq5V(from, to, true);
+    }
+}
+
+TEST(ApproxTSFinderTests, UndefOneSwapTest) {
+    {
+        InverseMap from { 0, _undef, 2, 4, _undef };
+        InverseMap to   { 0, _undef, 4, 2, _undef };
+        CheckSwapSeq5V(from, to, true);
+    }
+
+    {
+        InverseMap from { 1, _undef, 0, _undef, _undef };
+        InverseMap to   { 0, _undef, 1, _undef, _undef };
+        CheckSwapSeq5V(from, to, true);
+    }
+}
+
+TEST(ApproxTSFinderTests, UndefComplexSwapTest) {
+    {
+        InverseMap from { 0, _undef, 2, 4, _undef };
+        InverseMap to   { _undef, _undef, 4, 2, 0 };
+        CheckSwapSeq5V(from, to, true);
+    }
+
+    {
+        InverseMap from { 1, _undef, 0, _undef, _undef };
+        InverseMap to   { _undef, _undef, 1, _undef, 0 };
+        CheckSwapSeq5V(from, to, true);
+    }
+
+    {
+        InverseMap from { 1, _undef, 0, 4, 3 };
+        InverseMap to   { 4, 1, 0, 3, _undef };
+        CheckSwapSeq5V(from, to, true);
+    }
+}
+
+TEST(ApproxTSFinderTests, Undef16QComplexSwapTest) {
     {
         InverseMap from {
             0, 1, 2, 3,
@@ -236,7 +250,7 @@ TEST(ApproxTSFinderTests, Undef16QComplexSwapTest) {
             8, 9, 10, 11,
             12, 13, 14, 15
         };
-        CheckSwapSeq(graph, from, to, true);
+        CheckSwapSeq16V(from, to, true);
     }
 
     {
@@ -252,7 +266,7 @@ TEST(ApproxTSFinderTests, Undef16QComplexSwapTest) {
             8, 9, 10, 11,
             12, 13, 14, 15
         };
-        CheckSwapSeq(graph, from, to, true);
+        CheckSwapSeq16V(from, to, true);
     }
 
     {
@@ -268,7 +282,7 @@ TEST(ApproxTSFinderTests, Undef16QComplexSwapTest) {
             8, 9, 10, 11,
             12, 13, 14, 15
         };
-        CheckSwapSeq(graph, from, to, true);
+        CheckSwapSeq16V(from, to, true);
     }
 
     {
@@ -284,7 +298,7 @@ TEST(ApproxTSFinderTests, Undef16QComplexSwapTest) {
             0, 15, 1, 14,
             13, 3, 12, 4
         };
-        CheckSwapSeq(graph, from, to, true);
+        CheckSwapSeq16V(from, to, true);
     }
 
     {
@@ -300,7 +314,7 @@ TEST(ApproxTSFinderTests, Undef16QComplexSwapTest) {
             4, 12, 3, 13,
             14, 1, 15, 0
         };
-        CheckSwapSeq(graph, from, to, true);
+        CheckSwapSeq16V(from, to, true);
     }
 
     {
@@ -316,6 +330,6 @@ TEST(ApproxTSFinderTests, Undef16QComplexSwapTest) {
             7, 5, 4, 6,
             1, 3, 2, 0
         };
-        CheckSwapSeq(graph, from, to, true);
+        CheckSwapSeq16V(from, to, true);
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,9 @@ efd_test (BFSPathFinderTests
 efd_test (ApproxTSFinderTests
     EfdSupport)
 
+efd_test (SimplifiedApproxTSFinderTests
+    EfdSupport)
+
 efd_test (EnumStringTests
     EfdSupport)
 

--- a/tests/SimplifiedApproxTSFinderTests.cpp
+++ b/tests/SimplifiedApproxTSFinderTests.cpp
@@ -1,0 +1,335 @@
+#include "gtest/gtest.h"
+#include "enfield/Support/SimplifiedApproxTSFinder.h"
+#include "enfield/Support/ExpTSFinder.h"
+#include "enfield/Support/Timer.h"
+
+using namespace efd;
+
+static ExpTSFinder::uRef expFinder;
+static SimplifiedApproxTSFinder::uRef approxFinder5V;
+static SimplifiedApproxTSFinder::uRef approxFinder16V;
+
+static Graph::sRef graph5V;
+static Graph::sRef graph16V;
+
+static const std::string graph5VStr =
+"{\
+    \"vertices\": 5,\
+    \"type\": \"Undirected\",\
+    \"adj\": [\
+        [ {\"v\": 1}, {\"v\": 2} ],\
+        [ {\"v\": 2} ],\
+        [],\
+        [ {\"v\": 2}, {\"v\": 4} ],\
+        [ {\"v\": 2} ]\
+    ]\
+}";
+static const std::string graph16VStr =
+"{\
+    \"vertices\": 16,\
+    \"type\": \"Undirected\",\
+    \"adj\": [\
+        [ {\"v\": 1} ],\
+        [ {\"v\": 2} ],\
+        [ {\"v\": 3} ],\
+        [ {\"v\": 14} ],\
+        [ {\"v\": 3}, {\"v\": 5} ],\
+        [],\
+        [ {\"v\": 7}, {\"v\": 11} ],\
+        [ {\"v\": 10} ],\
+        [ {\"v\": 7} ],\
+        [ {\"v\": 8}, {\"v\": 10} ],\
+        [],\
+        [ {\"v\": 10} ],\
+        [ {\"v\": 5}, {\"v\": 11}, {\"v\": 13} ],\
+        [ {\"v\": 4}, {\"v\": 14} ],\
+        [],\
+        [ {\"v\": 0}, {\"v\": 14} ]\
+    ]\
+}";
+
+struct TestEnvironment : public ::testing::Environment {
+    void SetUp() override {
+        graph5V = JsonParser<efd::Graph>::ParseString(graph5VStr);
+        graph16V = JsonParser<efd::Graph>::ParseString(graph16VStr);
+
+        expFinder = ExpTSFinder::Create();
+        approxFinder5V = SimplifiedApproxTSFinder::Create();
+        approxFinder16V = SimplifiedApproxTSFinder::Create();
+
+        expFinder->setGraph(graph5V.get());
+        approxFinder5V->setGraph(graph5V.get());
+        approxFinder16V->setGraph(graph16V.get());
+    }
+};
+
+::testing::Environment* const env =
+::testing::AddGlobalTestEnvironment(new TestEnvironment());
+
+static void CheckSwapSeq(SimplifiedApproxTSFinder::Ref approx,
+                         const InverseMap& from,
+                         const InverseMap& to,
+                         bool hasUndef) {
+    Timer::Start();
+
+    auto approxseq = approx->find(from, to);
+
+    if (!hasUndef) {
+        auto expseq = expFinder->find(from, to);
+
+        ASSERT_TRUE(approxseq.size() <= 4 * expseq.size());
+
+        if (approxseq.size() != expseq.size()) {
+            std::cerr << "4-Approx: " << approxseq.size() << std::endl;
+            std::cerr << "Exp: " << expseq.size() << std::endl;
+        }
+    } else {
+        std::cerr << "4-Approx: " << approxseq.size() << std::endl;
+    }
+
+    auto _from = from;
+    if (!approxseq.empty()) {
+        for (auto swap : approxseq)
+            std::swap(_from[swap.u], _from[swap.v]);
+    }
+
+    ASSERT_EQ(_from, to);
+    std::cerr << "time: " << Timer::Stop<std::chrono::microseconds>() << std::endl;
+}
+
+static void CheckSwapSeq5V(const InverseMap& from, const InverseMap& to, bool hasUndef = false) {
+    CheckSwapSeq(approxFinder5V.get(), from, to, hasUndef);
+}
+
+static void CheckSwapSeq16V(const InverseMap& from, const InverseMap& to, bool hasUndef = true) {
+    CheckSwapSeq(approxFinder16V.get(), from, to, hasUndef);
+}
+
+TEST(ApproxTSFinderTests, NoSwapTest) {
+    {
+        InverseMap from { 0, 1, 2, 3, 4 };
+        InverseMap to   { 0, 1, 2, 3, 4 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 4, 3, 2, 1, 0 };
+        InverseMap to   { 4, 3, 2, 1, 0 };
+        CheckSwapSeq5V(from, to);
+    }
+}
+
+TEST(ApproxTSFinderTests, SimpleSwapTest) {
+    {
+        InverseMap from { 0, 1, 2, 4, 3 };
+        InverseMap to   { 0, 1, 2, 3, 4 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 0, 1, 2, 3, 4 };
+        InverseMap to   { 0, 1, 2, 4, 3 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 4, 3, 0, 1, 2 };
+        InverseMap to   { 4, 3, 2, 1, 0 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 4, 3, 2, 1, 0 };
+        InverseMap to   { 4, 3, 0, 1, 2 };
+        CheckSwapSeq5V(from, to);
+    }
+}
+
+TEST(ApproxTSFinderTests, ComplexSwapTest) {
+    {
+        InverseMap from { 0, 1, 2, 4, 3 };
+        InverseMap to   { 4, 3, 2, 1, 0 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 4, 3, 0, 1, 2 };
+        InverseMap to   { 0, 1, 2, 4, 3 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 3, 4, 2, 0, 1 };
+        InverseMap to   { 0, 1, 2, 3, 4 };
+        CheckSwapSeq5V(from, to);
+    }
+
+    {
+        InverseMap from { 3, 1, 2, 0, 4 };
+        InverseMap to   { 0, 1, 2, 3, 4 };
+        CheckSwapSeq5V(from, to);
+    }
+}
+
+TEST(ApproxTSFinderTests, AllPermutationsTest) {
+    std::vector<InverseMap> invs;
+    InverseMap perm { 0, 1, 2, 3, 4 };
+
+    do {
+        invs.push_back(perm);
+    } while (std::next_permutation(perm.begin(), perm.end()));
+
+    ASSERT_EQ(invs.size(), (uint32_t) 120);
+
+    uint32_t x = 0;
+    for (uint32_t i = 0, e = invs.size(); i < e; ++i)
+        for (uint32_t j = 0; j < e; ++j, ++x)
+            CheckSwapSeq5V(invs[i], invs[j]);
+}
+
+// Using undef
+TEST(ApproxTSFinderTests, UndefNoSwapTest) {
+    {
+        InverseMap from { 0, _undef, 2, 4, _undef };
+        InverseMap to   { 0, _undef, 2, 4, _undef };
+        CheckSwapSeq5V(from, to, true);
+    }
+
+    {
+        InverseMap from { _undef, _undef, _undef, _undef, _undef };
+        InverseMap to   { _undef, _undef, _undef, _undef, _undef };
+        CheckSwapSeq5V(from, to, true);
+    }
+}
+
+TEST(ApproxTSFinderTests, UndefOneSwapTest) {
+    {
+        InverseMap from { 0, _undef, 2, 4, _undef };
+        InverseMap to   { 0, _undef, 4, 2, _undef };
+        CheckSwapSeq5V(from, to, true);
+    }
+
+    {
+        InverseMap from { 1, _undef, 0, _undef, _undef };
+        InverseMap to   { 0, _undef, 1, _undef, _undef };
+        CheckSwapSeq5V(from, to, true);
+    }
+}
+
+TEST(ApproxTSFinderTests, UndefComplexSwapTest) {
+    {
+        InverseMap from { 0, _undef, 2, 4, _undef };
+        InverseMap to   { _undef, _undef, 4, 2, 0 };
+        CheckSwapSeq5V(from, to, true);
+    }
+
+    {
+        InverseMap from { 1, _undef, 0, _undef, _undef };
+        InverseMap to   { _undef, _undef, 1, _undef, 0 };
+        CheckSwapSeq5V(from, to, true);
+    }
+
+    {
+        InverseMap from { 1, _undef, 0, 4, 3 };
+        InverseMap to   { 4, 1, 0, 3, _undef };
+        CheckSwapSeq5V(from, to, true);
+    }
+}
+
+TEST(ApproxTSFinderTests, Undef16QComplexSwapTest) {
+    {
+        InverseMap from {
+            0, 1, 2, 3,
+            4, 5, 6, 7,
+            8, 9, 10, 11,
+            12, 13, 14, 15
+        };
+        InverseMap to {
+            0, 1, 2, 3,
+            4, 5, 6, 7,
+            8, 9, 10, 11,
+            12, 13, 14, 15
+        };
+        CheckSwapSeq16V(from, to, true);
+    }
+
+    {
+        InverseMap from {
+            0, 1, 2, 3,
+            4, 12, 6, 7,
+            8, 9, 10, 11,
+            5, 13, 14, 15
+        };
+        InverseMap to {
+            0, 1, 2, 3,
+            4, 5, 6, 7,
+            8, 9, 10, 11,
+            12, 13, 14, 15
+        };
+        CheckSwapSeq16V(from, to, true);
+    }
+
+    {
+        InverseMap from {
+            0, 1, 2, 3,
+            4, 5, 6, 7,
+            8, 9, 10, 11,
+            12, 13, 14, 15
+        };
+        InverseMap to {
+            3, 2, 1, 0,
+            4, 5, 6, 7,
+            8, 9, 10, 11,
+            12, 13, 14, 15
+        };
+        CheckSwapSeq16V(from, to, true);
+    }
+
+    {
+        InverseMap from {
+            0, 15, 1, 14,
+            13, 3, 12, 4,
+            _undef, _undef, _undef, _undef,
+            _undef, _undef, _undef, _undef
+        };
+        InverseMap to {
+            _undef, _undef, _undef, _undef,
+            _undef, _undef, _undef, _undef,
+            0, 15, 1, 14,
+            13, 3, 12, 4
+        };
+        CheckSwapSeq16V(from, to, true);
+    }
+
+    {
+        InverseMap from {
+            0, 15, 1, 14,
+            13, 3, 12, 4,
+            _undef, _undef, _undef, _undef,
+            _undef, _undef, _undef, _undef
+        };
+        InverseMap to {
+            _undef, _undef, _undef, _undef,
+            _undef, _undef, _undef, _undef,
+            4, 12, 3, 13,
+            14, 1, 15, 0
+        };
+        CheckSwapSeq16V(from, to, true);
+    }
+
+    {
+        InverseMap from {
+            0, 1, 2, 3,
+            4, 5, 6, 7,
+            _undef, _undef, _undef, _undef,
+            _undef, _undef, _undef, _undef
+        };
+        InverseMap to {
+            _undef, _undef, _undef, _undef,
+            _undef, _undef, _undef, _undef,
+            7, 5, 4, 6,
+            1, 3, 2, 0
+        };
+        CheckSwapSeq16V(from, to, true);
+    }
+}


### PR DESCRIPTION
In the first implementation of `ApproxTSFinder`, we handle the colored version of the problem, where we first execute the hungarian algorithm. However, the way we were using it didn't make it necessary. So, a faster version of it was created: `SimplifiedApproxTSFinder`. We basically ignore the unmapped qubits, and only care about the mapped ones (we remove the step where we had to minimum match the unmapped qubits from the source mapping into the closest unmapped ones in the target mapping).

Also, we optimized `ApproxTSFinder` by preprocessing the graph when it is set. We calculate a list of good vertices for every two pair of vertices. We do it in O(|Q||E|) time.