### PR TITLE
[BoundedMappingTreeQAllocator]: fix implementation.

### DIFF
--- a/include/enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h
+++ b/include/enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h
@@ -16,11 +16,15 @@ namespace efd {
             Dependencies mDeps;
         };
 
+        typedef std::priority_queue<NodeCandidate,
+                                    std::vector<NodeCandidate>,
+                                    std::greater<NodeCandidate>> NCPQueue;
+
         /// \brief `LessThan` operator that orders `NodeCandidate`s.
         ///
         /// It compares the weights and the `Node` pointer only, since the
         /// `mDeps` depends on it.
-        bool operator<(const NodeCandidate& lhs, const NodeCandidate& rhs);
+        bool operator>(const NodeCandidate& lhs, const NodeCandidate& rhs);
 
         /// \brief Composition of each candidate in phase 1.
         struct MappingCandidate {
@@ -188,16 +192,14 @@ namespace efd {
             bmt::MappingSwapSequence phase2(const bmt::MCandidateVCollection& collection);
             Mapping phase3(QModule::Ref qmod, const bmt::MappingSwapSequence& mss);
 
-            bmt::MCandidateVector
-                extendCandidates(Dep& dep,
-                                 const std::vector<bool>& mapped,
-                                 const bmt::MCandidateVector& candidates,
-                                 bool ignoreChildrenLimit);
+            bmt::MCandidateVector extendCandidates(Dep& dep,
+                                                   const std::vector<bool>& mapped,
+                                                   const bmt::MCandidateVector& candidates,
+                                                   bool ignoreChildrenLimit);
 
-            std::priority_queue<bmt::NodeCandidate>
-                rankCandidates(const std::vector<Node::Ref>& nodeCandidates,
-                               const std::vector<bool>& mapped,
-                               const std::vector<std::set<uint32_t>>& neighbors);
+            bmt::NCPQueue rankCandidates(const std::vector<Node::Ref>& nodeCandidates,
+                                         const std::vector<bool>& mapped,
+                                         const std::vector<std::set<uint32_t>>& neighbors);
 
             bmt::MappingSeq tracebackPath(const bmt::TIMatrix& mem, uint32_t idx);
             SwapSeq getTransformingSwapsFor(const Mapping& fromM, Mapping toM);

--- a/lib/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.cpp
+++ b/lib/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.cpp
@@ -158,7 +158,7 @@ Vector BestNMSSelector::select(const TIMatrix& mem) {
     uint32_t lastLayer = mem.size() - 1;
     std::priority_queue<UIntPair,
                         std::vector<UIntPair>,
-                        std::less<UIntPair>> pQueue;
+                        std::greater<UIntPair>> pQueue;
 
     for (uint32_t i = 0, e = mem[lastLayer].size(); i < e; ++i) {
         const auto &info = mem[lastLayer][i];

--- a/lib/Transform/Allocators/BoundedMappingTreeQAllocator.cpp
+++ b/lib/Transform/Allocators/BoundedMappingTreeQAllocator.cpp
@@ -464,7 +464,7 @@ BoundedMappingTreeQAllocator::phase2(const MCandidateVCollection& collection) {
                 // uint32_t mappingCost = mem[i - 1][k].mappingCost;
                 // Should be this one.
                 uint32_t mappingCost = mem[i - 1][k].mappingCost + collection[i][j].cost;
-                uint32_t swapEstimatedCost = mCostEstimator->estimate(lastMapping, mapping) +
+                uint32_t swapEstimatedCost = mCostEstimator->estimate(lastMapping, mapping) * 30 +
                     mem[i - 1][k].swapEstimatedCost;
 
                 if (mappingCost + swapEstimatedCost < best.mappingCost + best.swapEstimatedCost) {

--- a/lib/Transform/Allocators/BoundedMappingTreeQAllocator.cpp
+++ b/lib/Transform/Allocators/BoundedMappingTreeQAllocator.cpp
@@ -34,9 +34,9 @@ static Stat<double> Phase3Time
 static Stat<uint32_t> Partitions
 ("BMTPartitions", "Number of partitions split by *BMT allocators.");
 
-bool efd::bmt::operator<(const NodeCandidate& lhs, const NodeCandidate& rhs) {
-    if (lhs.mWeight != rhs.mWeight) return lhs.mWeight < rhs.mWeight;
-    return lhs.mNode < rhs.mNode;
+bool efd::bmt::operator>(const NodeCandidate& lhs, const NodeCandidate& rhs) {
+    if (lhs.mWeight != rhs.mWeight) return lhs.mWeight > rhs.mWeight;
+    return lhs.mNode > rhs.mNode;
 }
 
 // --------------------- NodeCandidatesGenerator ------------------------
@@ -244,11 +244,11 @@ BoundedMappingTreeQAllocator::extendCandidates(Dep& dep,
     return mPartialSolutionCSelector->select(mMaxPartial, newCandidates);
 }
 
-std::priority_queue<NodeCandidate>
+NCPQueue
 BoundedMappingTreeQAllocator::rankCandidates(const std::vector<Node::Ref>& nodeCandidates,
                                              const std::vector<bool>& mapped,
                                              const std::vector<std::set<uint32_t>>& neighbors) {
-    std::priority_queue<NodeCandidate> queue;
+    NCPQueue queue;
 
     for (auto node : nodeCandidates) {
         NodeCandidate nCand;


### PR DESCRIPTION
Whenever using `std::priority_queue`, we were not setting the comparator, assuming that it would use `std::less` by default (which it does). However, by using `std::less`, it sorts in decreasing order (and not increasing order, which was expected). Thus, we changed them all to `std::greater`, fixing the issue.