### PR TITLE
Log Fixes and Initialization Procedures

### DIFF
--- a/include/enfield/Support/Defs.h
+++ b/include/enfield/Support/Defs.h
@@ -23,14 +23,17 @@ namespace efd {
     typedef std::vector<Swap> SwapSeq;
 
     /// \brief Returns a stream object for logging errors.
-    std::ostream& ErrorLog(std::string file = "", uint32_t line = 0);
+    std::ostream& ErrorLog(const std::string& file = "", const uint32_t& line = 0);
     /// \brief Returns a stream object for logging warnings.
-    std::ostream& WarningLog(std::string file = "", uint32_t line = 0);
+    std::ostream& WarningLog(const std::string& file = "", const uint32_t& line = 0);
     /// \brief Returns a stream object for logging information.
-    std::ostream& InfoLog(std::string file = "", uint32_t line = 0);
+    std::ostream& InfoLog(const std::string& file = "", const uint32_t& line = 0);
+
+    /// \brief Initialize the log files.
+    void InitializeLogs();
 
     /// \brief Aborts reporting the file and the line.
-    void Abort [[noreturn]] (std::string file = "", uint32_t line = 0);
+    void Abort [[noreturn]] (const std::string& file = "", const uint32_t& line = 0);
 }
 
 #ifndef EFD_MESSAGE_LOG

--- a/include/enfield/Transform/Driver.h
+++ b/include/enfield/Transform/Driver.h
@@ -31,6 +31,15 @@ namespace efd {
 
     /// \brief Print the dependency graph of the \p qmod in \p o.
     void PrintDependencyGraph(QModule::Ref qmod, std::ostream& o = std::cout);
+
+    /// \brief Initializes Enfield.
+    ///
+    /// This registers all architectures and allocators, as well as initializes the
+    /// log files. If you call this function, there is no need for calling:
+    ///     - ParseArguments;
+    ///     - InitializeAllArchitectures; and
+    ///     - InitializeAllQbitAllocators.
+    void Init(int argc, char** argv);
 }
 
 #endif

--- a/lib/Support/Defs.cpp
+++ b/lib/Support/Defs.cpp
@@ -4,20 +4,39 @@
 #include <iostream>
 #include <fstream>
 
-static efd::Opt<std::string> ErrorFile
-("err", "File to keep error messages.", "/dev/stderr", false);
-static efd::Opt<std::string> WarningFile
-("war", "File to keep warning messages.", "/dev/stdout", false);
-static efd::Opt<std::string> InfoFile
-("inf", "File to keep information messages.", "/dev/stdout", false);
+#define EFD_PREFIX_COLOR "\e[38;5;"
+#define EFD_RESET_COLOR "\e[0m"
 
+#ifndef EFD_ERR_COLOR
+#define EFD_ERR_COLOR 9
+#endif
+
+#ifndef EFD_WAR_COLOR
+#define EFD_WAR_COLOR 3
+#endif
+
+#ifndef EFD_INF_COLOR
+#define EFD_INF_COLOR 14
+#endif
+
+static efd::Opt<std::string> ErrorFile
+("err", "File to keep error messages.", "", false);
+static efd::Opt<std::string> WarningFile
+("war", "File to keep warning messages.", "", false);
+static efd::Opt<std::string> InfoFile
+("inf", "File to keep information messages.", "", false);
+
+static efd::Opt<bool> NoColor
+("-no-color", "Do not print color characters.", false, false);
 static efd::Opt<bool> Verbose
 ("v", "Verbose. You know... That thing everyone does!", false, false);
 
-static void PrintMessage(std::ostream& out,
-                         std::string level, std::string file,
-                         uint32_t line) {
-    out << "[" << level << "]: ";
+static inline
+void PrintMessage(std::ostream& out,
+                  const std::string& prefix,
+                  const std::string& file,
+                  const uint32_t& line) {
+    out << prefix;
 
     if (Verbose.getVal() && file != "" && line != 0) {
         out << file << ":" << line << ":" << std::endl;
@@ -25,25 +44,40 @@ static void PrintMessage(std::ostream& out,
     }
 }
 
-std::ostream& efd::ErrorLog(std::string file, uint32_t line) {
-    static std::ofstream out(ErrorFile.getVal());
-    PrintMessage(out, "ERROR", file, line);
-    return out;
+#define EFD_IMPLEMENT_LOG(_fnName_, _level_, _cl_, _default_, _color_)              \
+    static std::ostream* _fnName_##Stream = &_default_;                             \
+    static const std::string _fnName_##UncoloredPrefix = "[" _level_ "]: ";         \
+    static const std::string _fnName_##ColoredPrefix =                              \
+        EFD_PREFIX_COLOR #_color_ "m" + _fnName_##UncoloredPrefix + EFD_RESET_COLOR;\
+    static const std::string* _fnName_##Prefix = &_fnName_##ColoredPrefix;          \
+                                                                                    \
+    std::ostream& efd::_fnName_(const std::string& file, const uint32_t& line) {    \
+        PrintMessage(*_fnName_##Stream, *_fnName_##Prefix, file, line);             \
+        return *_fnName_##Stream;                                                   \
+    }                                                                               \
+                                                                                    \
+    static void Initialize##_fnName_() {                                            \
+        static std::ofstream _fnName_##ClFile;                                      \
+        if (!_cl_.getVal().empty()) {                                               \
+            _fnName_##ClFile.open(_cl_.getVal());                                   \
+            _fnName_##Stream = &_fnName_##ClFile;                                   \
+            _fnName_##Prefix = &_fnName_##UncoloredPrefix;                          \
+        } else if (NoColor.getVal()) {                                              \
+            _fnName_##Prefix = &_fnName_##UncoloredPrefix;                          \
+        }                                                                           \
+    }
+
+EFD_IMPLEMENT_LOG(ErrorLog, "ERROR", ErrorFile, std::cerr, 9)
+EFD_IMPLEMENT_LOG(WarningLog, "WARNING", WarningFile, std::cout, 3)
+EFD_IMPLEMENT_LOG(InfoLog, "INFO", InfoFile, std::cout, 2)
+
+void efd::InitializeLogs() {
+    InitializeErrorLog();
+    InitializeWarningLog();
+    InitializeInfoLog();
 }
 
-std::ostream& efd::WarningLog(std::string file, uint32_t line) {
-    static std::ofstream out(WarningFile.getVal());
-    PrintMessage(out, "WARNING", file, line);
-    return out;
-}
-
-std::ostream& efd::InfoLog(std::string file, uint32_t line) {
-    static std::ofstream out(InfoFile.getVal());
-    PrintMessage(out, "INFO", file, line);
-    return out;
-}
-
-void efd::Abort(std::string file, uint32_t line) {
+void efd::Abort(const std::string& file, const uint32_t& line) {
     std::cerr << "Enfield Aborted on file `" << file << "`, line `" << line << "`." 
               << std::endl;
     std::abort();

--- a/lib/Transform/Driver.cpp
+++ b/lib/Transform/Driver.cpp
@@ -122,3 +122,10 @@ void efd::PrintDependencyGraph(QModule::Ref qmod, std::ostream& o) {
     StatDepGraphDensity = ((double) StatNofEdges.getVal()) /
         ((double) StatNofVertices.getVal() * StatNofVertices.getVal());
 }
+
+void efd::Init(int argc, char** argv) {
+    InitializeAllQbitAllocators();
+    InitializeAllArchitectures();
+    ParseArguments(argc, argv);
+    InitializeLogs();
+}

--- a/tools/Enfield.cpp
+++ b/tools/Enfield.cpp
@@ -58,9 +58,9 @@ Should be specified as <gate>:<w> between quotes.",
 {{"U", 1}, {"CX", 10}}, false);
 
 static Opt<std::string> InFilepath
-("i", "The input file.", "/dev/stdin", true);
+("i", "The input file.", "", true);
 static Opt<std::string> OutFilepath
-("o", "The output file.", "/dev/stdout", false);
+("o", "The output file.", "", false);
 static Opt<std::string> ArchFilepath
 ("arch-file", "An input file for using a custom architecture.", "", false);
 
@@ -96,9 +96,10 @@ static efd::Stat<uint32_t> WeightedCost
 ("WeightedCost", "Total weighted cost after allocating the qubits.");
 
 static void DumpToOutFile(QModule::Ref qmod) {
-    std::ofstream O(OutFilepath.getVal());
-    PrintToStream(qmod, O, !NoPretty.getVal());
-    O.close();
+    std::ofstream cmdOut(OutFilepath.getVal());
+    std::ostream& out = (OutFilepath.getVal() != "") ? cmdOut : std::cout;
+    PrintToStream(qmod, out, !NoPretty.getVal());
+    cmdOut.close();
 }
 
 static void ComputeStats(QModule::Ref qmod, ArchGraph::sRef archGraph) {
@@ -117,10 +118,7 @@ static void ComputeStats(QModule::Ref qmod, ArchGraph::sRef archGraph) {
 }
 
 int main(int argc, char** argv) {
-    InitializeAllQbitAllocators();
-    InitializeAllArchitectures();
-
-    ParseArguments(argc, argv);
+    Init(argc, argv);
     QModule::uRef qmod = ParseFile(InFilepath.getVal());
 
     if (qmod.get() != nullptr) {


### PR DESCRIPTION
Whenever we ran enfield, both INF, WAR, and the utility for dumping QASM files found in `Enfield.cpp` openned '/dev/stdout'. It wasn't portable and was susceptible to data races.
It is a subtle bug, but it makes debugging really bad.