### PR TITLE
`InlineAllPass` is faster now!

### DIFF
--- a/include/enfield/Transform/InlineAllPass.h
+++ b/include/enfield/Transform/InlineAllPass.h
@@ -16,6 +16,10 @@ namespace efd {
 
         private:
             std::set<std::string> mBasis;
+            std::unordered_map<std::string, NDGateDecl::Ref> mGateDeclarations;
+            std::unordered_map<std::string, std::vector<Node::uRef>> mGateInlinedInstructions;
+
+            std::vector<Node::uRef> getInlinedInstructionForGate(const std::string& gateName);
             
         public:
             InlineAllPass(std::vector<std::string> basis = std::vector<std::string>());

--- a/include/enfield/Transform/InlineAllPass.h
+++ b/include/enfield/Transform/InlineAllPass.h
@@ -19,6 +19,8 @@ namespace efd {
             std::unordered_map<std::string, NDGateDecl::Ref> mGateDeclarations;
             std::unordered_map<std::string, std::vector<Node::uRef>> mGateInlinedInstructions;
 
+            void appendInlinedInstructionsOfNode(Node::Ref node,
+                                                 std::vector<Node::uRef>& inlined);
             std::vector<Node::uRef> getInlinedInstructionForGate(const std::string& gateName);
             
         public:

--- a/include/enfield/Transform/QModule.h
+++ b/include/enfield/Transform/QModule.h
@@ -80,6 +80,7 @@ namespace efd {
             Iterator insertStatementFront(Node::uRef ref);
             /// \brief Inserts \p ref at the back, and returns a iterator to this node.
             Iterator insertStatementLast(Node::uRef ref);
+            Iterator insertStatementLast(std::vector<Node::uRef> stmts);
 
             /// \brief Replaces the \p stmt by the vector \p stmts.
             Iterator replaceStatement(Node::Ref stmt, std::vector<Node::uRef> stmts);

--- a/include/enfield/Transform/Utils.h
+++ b/include/enfield/Transform/Utils.h
@@ -7,15 +7,26 @@
 #include <map>
 
 namespace efd {
-    typedef std::map<std::string, uint32_t> GateWeightMap;
-    typedef std::vector<std::string> GateNameVector;
-    typedef std::pair<NDIfStmt::Ref, NDQOp::Ref> StatementPair;
+    using GateWeightMap = std::map<std::string, uint32_t>;
+    using GateNameVector = std::vector<std::string>;
+    using StatementPair = std::pair<NDIfStmt::Ref, NDQOp::Ref>;
+    using InlineArgMap = std::unordered_map<std::string, Node::Ref>;
 
     /// \brief Extracts only the gate names to a separate vector.
     GateNameVector ExtractGateNames(const GateWeightMap& map);
     /// \brief Breakdowns the \p node into \em NDIfStmt and \em NDQOp pair.
     StatementPair GetStatementPair(const Node::Ref node);
 
+    /// \brief Create an \em InlineArgMap for \p call and \p gateDecl.
+    ///
+    /// Creates a mapping from the qubits used in \p gateDecl to the qubits used
+    /// in \p call. It prepares for inlining.
+    InlineArgMap CreateInlineArgMap(NDGateDecl::Ref gateDecl, NDQOp::Ref call);
+    /// \brief Replace the qubits used in \p inlinedInstructions according to
+    /// the mapping \p argMap.
+    void ReplaceInlineArgMap(const InlineArgMap& argMap,
+                             std::vector<Node::uRef>& inlinedInstructions,
+                             NDIfStmt::Ref ifstmt = nullptr);
     /// \brief If found, inlines the gate that \p qop calls.
     void InlineGate(QModule::Ref qmod, NDQOp::Ref qop);
     /// \brief Processes the \p root node, and transform the entire AST into

--- a/lib/Analysis/Nodes.cpp
+++ b/lib/Analysis/Nodes.cpp
@@ -364,6 +364,7 @@ efd::Node::Iterator efd::NDList::addChild(Iterator it, Node::uRef child) {
 }
 
 efd::Node::Iterator efd::NDList::addChildren(std::vector<Node::uRef> children) {
+    mChild.reserve(mChild.size() + children.size());
     auto it = addChildren(mChild.end(), std::move(children));
     return it;
 }

--- a/lib/Transform/Allocators/BoundedMappingTreeQAllocator.cpp
+++ b/lib/Transform/Allocators/BoundedMappingTreeQAllocator.cpp
@@ -591,9 +591,7 @@ Mapping BoundedMappingTreeQAllocator::phase3(QModule::Ref qmod, const MappingSwa
     }
 
     qmod->clearStatements();
-    for (auto& instr : issuedInstructions) {
-        qmod->insertStatementLast(std::move(instr));
-    }
+    qmod->insertStatementLast(std::move(issuedInstructions));
 
     return initial;
 }

--- a/lib/Transform/Allocators/GreedyCktQAllocator.cpp
+++ b/lib/Transform/Allocators/GreedyCktQAllocator.cpp
@@ -292,9 +292,7 @@ StdSolution GreedyCktQAllocator::buildStdSolution(QModule::Ref qmod) {
     }
 
     qmod->clearStatements();
-    for (auto& node : allocatedStatements) {
-        qmod->insertStatementLast(std::move(node));
-    }
+    qmod->insertStatementLast(std::move(allocatedStatements));
 
     return sol;
 }

--- a/lib/Transform/Allocators/IBMQAllocator.cpp
+++ b/lib/Transform/Allocators/IBMQAllocator.cpp
@@ -327,9 +327,7 @@ StdSolution IBMQAllocator::buildStdSolution(QModule::Ref qmod) {
     }
 
     qmod->clearStatements();
-    for (auto& node : newStatements) {
-        qmod->insertStatementLast(std::move(node));
-    }
+    qmod->insertStatementLast(std::move(newStatements));
 
     return sol;
 }

--- a/lib/Transform/InlineAllPass.cpp
+++ b/lib/Transform/InlineAllPass.cpp
@@ -1,34 +1,7 @@
 #include "enfield/Transform/InlineAllPass.h"
 #include "enfield/Transform/Utils.h"
-#include "enfield/Analysis/NodeVisitor.h"
 
 using namespace efd;
-
-// ==--------------- InlineAllVisitor ---------------==
-namespace efd {
-    class InlineAllVisitor : public NodeVisitor {
-        private:
-            std::set<std::string> mBasis;
-
-        public:
-            std::vector<NDQOp::Ref> mInlineVector;
-
-            InlineAllVisitor(std::set<std::string> basis) : mBasis(basis) {}
-
-            void visit(NDQOpGen::Ref ref) override;
-            void visit(NDIfStmt::Ref ref) override;
-    };
-}
-
-void InlineAllVisitor::visit(NDQOpGen::Ref ref) {
-    if (mBasis.find(ref->getOperation()) == mBasis.end()) {
-        mInlineVector.push_back(ref);
-    }
-}
-
-void InlineAllVisitor::visit(NDIfStmt::Ref ref) {
-    ref->getQOp()->apply(this);
-}
 
 // ==--------------- InlineAllPass ---------------==
 uint8_t efd::InlineAllPass::ID = 0;
@@ -37,35 +10,39 @@ InlineAllPass::InlineAllPass(std::vector<std::string> basis) {
     mBasis = std::set<std::string>(basis.begin(), basis.end());
 }
 
+void InlineAllPass::appendInlinedInstructionsOfNode(Node::Ref node,
+                                                    std::vector<Node::uRef>& inlined) {
+    auto sPair = GetStatementPair(node);
+    auto innerGateName = sPair.second->getOperation();
+    
+    NDGateDecl::Ref innerGateDecl = nullptr;
+    
+    if (mGateDeclarations.find(innerGateName) != mGateDeclarations.end()) {
+        innerGateDecl = mGateDeclarations[innerGateName];
+    }
+    
+    // We will inline `node` iff it isn't listed as one of the basis
+    // gates, and we can find an implementation.
+    if (mBasis.find(innerGateName) == mBasis.end() && innerGateDecl != nullptr) {
+        auto argMap = CreateInlineArgMap(innerGateDecl, sPair.second);
+        auto innerInlinedInstr = getInlinedInstructionForGate(innerGateName);
+    
+        ReplaceInlineArgMap(argMap, innerInlinedInstr, sPair.first);
+        inlined.insert(inlined.end(),
+                       std::make_move_iterator(innerInlinedInstr.begin()),
+                       std::make_move_iterator(innerInlinedInstr.end()));
+    } else {
+        inlined.push_back(node->clone());
+    }
+}
+
 std::vector<Node::uRef> InlineAllPass::getInlinedInstructionForGate(const std::string& gateName) {
     if (mGateInlinedInstructions.find(gateName) == mGateInlinedInstructions.end()) {
         // For each quantum operation `node` inside the gate `gateName`, we try to
         // inline it. Otherwise, we just clone it.
         std::vector<Node::uRef> inlinedInstructions;
-
         for (auto& node : *(mGateDeclarations[gateName]->getGOpList())) {
-            auto sPair = GetStatementPair(node.get());
-            auto innerGateName = sPair.second->getOperation();
-
-            NDGateDecl::Ref innerGateDecl = nullptr;
-
-            if (mGateDeclarations.find(innerGateName) != mGateDeclarations.end()) {
-                innerGateDecl = mGateDeclarations[innerGateName];
-            }
-
-            // We will inline `node` iff it isn't listed as one of the basis
-            // gates, and we can find an implementation.
-            if (mBasis.find(innerGateName) == mBasis.end() && innerGateDecl != nullptr) {
-                auto argMap = CreateInlineArgMap(innerGateDecl, sPair.second);
-                auto innerInlinedInstr = getInlinedInstructionForGate(innerGateName);
-
-                ReplaceInlineArgMap(argMap, innerInlinedInstr, sPair.first);
-                inlinedInstructions.insert(inlinedInstructions.end(),
-                                           std::make_move_iterator(innerInlinedInstr.begin()),
-                                           std::make_move_iterator(innerInlinedInstr.end()));
-            } else {
-                inlinedInstructions.push_back(node->clone());
-            }
+            appendInlinedInstructionsOfNode(node.get(), inlinedInstructions);
         }
 
         // Saving the inlined instructions in a cache for future use.
@@ -83,19 +60,9 @@ std::vector<Node::uRef> InlineAllPass::getInlinedInstructionForGate(const std::s
 }
 
 bool InlineAllPass::run(QModule::Ref qmod) {
-    InlineAllVisitor visitor(mBasis);
-
-    mGateDeclarations.clear();
-    mGateInlinedInstructions.clear();
-
     bool changed = false;
 
-    // First, we need to get all the nodes that should be replaced.
-    for (auto it = qmod->stmt_begin(), e = qmod->stmt_end(); it != e; ++it) {
-        (*it)->apply(&visitor);
-    }
-
-    // Then, we create an map entry for each gate within the `QModule`,
+    // We create an map entry for each gate within the `QModule`,
     // mapping its name to its declaration (`nullptr` if none).
     for (auto it = qmod->gates_begin(), end = qmod->gates_end(); it != end; ++it) {
         mGateDeclarations[(*it)->getId()->getVal()] = dynCast<NDGateDecl>(*it);
@@ -103,21 +70,14 @@ bool InlineAllPass::run(QModule::Ref qmod) {
 
     // Finally, we will replace the nodes only if we were able to find an
     // implementation for them. Otherwise, we do nothing.
-    for (auto node : visitor.mInlineVector) {
-        auto gateName = node->getOperation();
-        auto gateDecl = mGateDeclarations[gateName];
-
-        if (gateDecl != nullptr) {
-            auto inlinedInstructions = getInlinedInstructionForGate(gateName);
-            auto argMap = CreateInlineArgMap(gateDecl, node);
-
-            auto ifstmt = dynCast<NDIfStmt>(node->getParent());
-            ReplaceInlineArgMap(argMap, inlinedInstructions, ifstmt);
-            qmod->replaceStatement((ifstmt == nullptr) ? (Node::Ref) node : (Node::Ref)ifstmt,
-                                   std::move(inlinedInstructions));
-            changed = true;
-        }
+    std::vector<Node::uRef> newStatements;
+    newStatements.reserve(qmod->getNumberOfStmts());
+    for (auto it = qmod->stmt_begin(), e = qmod->stmt_end(); it != e; ++it) {
+        appendInlinedInstructionsOfNode(it->get(), newStatements);
     }
+
+    qmod->clearStatements();
+    qmod->insertStatementLast(std::move(newStatements));
 
     return changed;
 }

--- a/lib/Transform/InlineAllPass.cpp
+++ b/lib/Transform/InlineAllPass.cpp
@@ -1,8 +1,10 @@
 #include "enfield/Transform/InlineAllPass.h"
+#include "enfield/Transform/Utils.h"
 #include "enfield/Analysis/NodeVisitor.h"
 
-uint8_t efd::InlineAllPass::ID = 0;
+using namespace efd;
 
+// ==--------------- InlineAllVisitor ---------------==
 namespace efd {
     class InlineAllVisitor : public NodeVisitor {
         private:
@@ -18,47 +20,108 @@ namespace efd {
     };
 }
 
-void efd::InlineAllVisitor::visit(NDQOpGen::Ref ref) {
-    if (mBasis.find(ref->getId()->getVal()) == mBasis.end()) {
+void InlineAllVisitor::visit(NDQOpGen::Ref ref) {
+    if (mBasis.find(ref->getOperation()) == mBasis.end()) {
         mInlineVector.push_back(ref);
     }
 }
 
-void efd::InlineAllVisitor::visit(NDIfStmt::Ref ref) {
+void InlineAllVisitor::visit(NDIfStmt::Ref ref) {
     ref->getQOp()->apply(this);
 }
 
-efd::InlineAllPass::InlineAllPass(std::vector<std::string> basis) {
+// ==--------------- InlineAllPass ---------------==
+uint8_t efd::InlineAllPass::ID = 0;
+
+InlineAllPass::InlineAllPass(std::vector<std::string> basis) {
     mBasis = std::set<std::string>(basis.begin(), basis.end());
 }
 
-bool efd::InlineAllPass::run(QModule::Ref qmod) {
-    InlineAllVisitor visitor(mBasis);
+std::vector<Node::uRef> InlineAllPass::getInlinedInstructionForGate(const std::string& gateName) {
+    if (mGateInlinedInstructions.find(gateName) == mGateInlinedInstructions.end()) {
+        // For each quantum operation `node` inside the gate `gateName`, we try to
+        // inline it. Otherwise, we just clone it.
+        std::vector<Node::uRef> inlinedInstructions;
 
-    bool changed = false;
+        for (auto& node : *(mGateDeclarations[gateName]->getGOpList())) {
+            auto sPair = GetStatementPair(node.get());
+            auto innerGateName = sPair.second->getOperation();
 
-    do {
-        visitor.mInlineVector.clear();
-        // Inline until we can't inline anything anymore.
-        for (auto it = qmod->stmt_begin(), e = qmod->stmt_end(); it != e; ++it) {
-            (*it)->apply(&visitor);
-        }
+            NDGateDecl::Ref innerGateDecl = nullptr;
 
-        for (auto call : visitor.mInlineVector) {
-            auto sign = qmod->getQGate(call->getId()->getVal());
+            if (mGateDeclarations.find(innerGateName) != mGateDeclarations.end()) {
+                innerGateDecl = mGateDeclarations[innerGateName];
+            }
 
-            // Inline only non-opaque gates.
-            if (!sign->isOpaque()) {
-                qmod->inlineCall(call);
+            // We will inline `node` iff it isn't listed as one of the basis
+            // gates, and we can find an implementation.
+            if (mBasis.find(innerGateName) == mBasis.end() && innerGateDecl != nullptr) {
+                auto argMap = CreateInlineArgMap(innerGateDecl, sPair.second);
+                auto innerInlinedInstr = getInlinedInstructionForGate(innerGateName);
+
+                ReplaceInlineArgMap(argMap, innerInlinedInstr, sPair.first);
+                inlinedInstructions.insert(inlinedInstructions.end(),
+                                           std::make_move_iterator(innerInlinedInstr.begin()),
+                                           std::make_move_iterator(innerInlinedInstr.end()));
+            } else {
+                inlinedInstructions.push_back(node->clone());
             }
         }
 
-        if (!visitor.mInlineVector.empty()) changed = true;
-    } while (!visitor.mInlineVector.empty());
+        // Saving the inlined instructions in a cache for future use.
+        mGateInlinedInstructions[gateName] = std::move(inlinedInstructions);
+    }
+
+    // Finally, we clone the inlined instructions, and return them.
+    std::vector<Node::uRef> inlinedInstructions;
+
+    for (auto& instr : mGateInlinedInstructions[gateName]) {
+        inlinedInstructions.push_back(instr->clone());
+    }
+
+    return inlinedInstructions;
+}
+
+bool InlineAllPass::run(QModule::Ref qmod) {
+    InlineAllVisitor visitor(mBasis);
+
+    mGateDeclarations.clear();
+    mGateInlinedInstructions.clear();
+
+    bool changed = false;
+
+    // First, we need to get all the nodes that should be replaced.
+    for (auto it = qmod->stmt_begin(), e = qmod->stmt_end(); it != e; ++it) {
+        (*it)->apply(&visitor);
+    }
+
+    // Then, we create an map entry for each gate within the `QModule`,
+    // mapping its name to its declaration (`nullptr` if none).
+    for (auto it = qmod->gates_begin(), end = qmod->gates_end(); it != end; ++it) {
+        mGateDeclarations[(*it)->getId()->getVal()] = dynCast<NDGateDecl>(*it);
+    }
+
+    // Finally, we will replace the nodes only if we were able to find an
+    // implementation for them. Otherwise, we do nothing.
+    for (auto node : visitor.mInlineVector) {
+        auto gateName = node->getOperation();
+        auto gateDecl = mGateDeclarations[gateName];
+
+        if (gateDecl != nullptr) {
+            auto inlinedInstructions = getInlinedInstructionForGate(gateName);
+            auto argMap = CreateInlineArgMap(gateDecl, node);
+
+            auto ifstmt = dynCast<NDIfStmt>(node->getParent());
+            ReplaceInlineArgMap(argMap, inlinedInstructions, ifstmt);
+            qmod->replaceStatement((ifstmt == nullptr) ? (Node::Ref) node : (Node::Ref)ifstmt,
+                                   std::move(inlinedInstructions));
+            changed = true;
+        }
+    }
 
     return changed;
 }
 
-efd::InlineAllPass::uRef efd::InlineAllPass::Create(std::vector<std::string> basis) {
+InlineAllPass::uRef InlineAllPass::Create(std::vector<std::string> basis) {
     return uRef(new InlineAllPass(basis));
 }

--- a/lib/Transform/QModule.cpp
+++ b/lib/Transform/QModule.cpp
@@ -105,8 +105,15 @@ efd::QModule::Iterator efd::QModule::insertStatementFront(Node::uRef ref) {
 }
 
 efd::QModule::Iterator efd::QModule::insertStatementLast(Node::uRef ref) {
+    auto oldChildNumber = mStatements->getChildNumber();
     mStatements->addChild(std::move(ref));
-    return mStatements->begin() + (mStatements->getChildNumber() - 1);
+    return mStatements->begin() + oldChildNumber;
+}
+
+efd::QModule::Iterator efd::QModule::insertStatementLast(std::vector<Node::uRef> stmts) {
+    auto oldChildNumber = mStatements->getChildNumber();
+    mStatements->addChildren(std::move(stmts));
+    return mStatements->begin() + oldChildNumber;
 }
 
 efd::QModule::Iterator efd::QModule::replaceStatement


### PR DESCRIPTION
Previous implementation of `InlineAllPass` was greedy and dumb. For every callpoint, we inlined the gates in a Top-Down approach.

Now, first we inline the nodes inside the gate we would be inlining. Not only that, we also cache the "to-be-inlined" gates. So, it is 243248327x fast (depending on the program).