### PR TITLE
Refactor `EFD_ABORT` so that it accept conditionals.

### DIFF
--- a/include/enfield/Support/BitOptions.h
+++ b/include/enfield/Support/BitOptions.h
@@ -39,11 +39,7 @@ efd::BitOptions<ETy, last>::BitOptions() {
 template <typename ETy, ETy last>
 std::pair<uint32_t, uint32_t> efd::BitOptions<ETy, last>::getBlkAndBit(ETy option) const {
     uint32_t iOpt = static_cast<uint32_t>(option);
-
-    if (iOpt > Last) {
-        ERR << "Invalid Option: " << iOpt << ". Max: " << Last << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(iOpt > Last, "Invalid Option: " << iOpt << ". Max: " << Last);
 
     uint32_t blk = iOpt / ElemSize;
     uint32_t bit = iOpt % ElemSize;

--- a/include/enfield/Support/CommandLine.h
+++ b/include/enfield/Support/CommandLine.h
@@ -137,8 +137,7 @@ namespace efd {
 
 template <typename T>
 void efd::ParseOptTrait<T>::Run(Opt<T>* opt, std::vector<std::string> args) {
-    ERR << "Parse method not implemented for '" << typeid(T).name() << "'." << std::endl;
-    EFD_ABORT();
+    EfdAbortIf(true, "Parse method not implemented for '" << typeid(T).name() << "'.");
 }
 
 template <typename T, T first, T last, uint32_t padding>

--- a/include/enfield/Support/Defs.h
+++ b/include/enfield/Support/Defs.h
@@ -36,12 +36,21 @@ namespace efd {
     void Abort [[noreturn]] (const std::string& file = "", const uint32_t& line = 0);
 }
 
+// Beginning of EFD_MESSAGE_LOG ifdef
 #ifndef EFD_MESSAGE_LOG
 #define EFD_MESSAGE_LOG
-#define EFD_ABORT() Abort(__FILE__, __LINE__)
-#define ERR ErrorLog(__FILE__, __LINE__)
-#define WAR WarningLog(__FILE__, __LINE__)
-#define INF InfoLog(__FILE__, __LINE__)
+
+#define ERR efd::ErrorLog(__FILE__, __LINE__)
+#define WAR efd::WarningLog(__FILE__, __LINE__)
+#define INF efd::InfoLog(__FILE__, __LINE__)
+
+#define EfdAbortIf(_Cond_, _Message_)   \
+    if (_Cond_) {                       \
+        ERR << _Message_ << std::endl;  \
+        efd::Abort(__FILE__, __LINE__); \
+    }
+
 #endif
+// End of EFD_MESSAGE_LOG ifdef
 
 #endif

--- a/include/enfield/Support/DijkstraPathFinder.h
+++ b/include/enfield/Support/DijkstraPathFinder.h
@@ -40,11 +40,7 @@ template <typename T>
 std::vector<uint32_t>
 efd::DijkstraPathFinder<T>::find(Graph::Ref g, uint32_t u, uint32_t v) {
     auto wg = dynCast<WeightedGraph<T>>(g);
-
-    if (wg == nullptr) {
-        ERR << "Invalid weighted graph for this Dijkstra implementation." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(wg == nullptr, "Invalid weighted graph for this Dijkstra implementation.");
 
     uint32_t size = wg->size();
     uint32_t from = u;
@@ -78,11 +74,7 @@ efd::DijkstraPathFinder<T>::find(Graph::Ref g, uint32_t u, uint32_t v) {
     }
 
     // Reconstructing the path
-    if (equal(dist[to], infw)) {
-        ERR << "No existing path in this graph." << std::endl;
-        EFD_ABORT();
-    }
-
+    EfdAbortIf(equal(dist[to], infw), "No existing path in this graph.");
     std::vector<uint32_t> path;
 
     // If the path is "from -> x -> y -> to", the swap vector will contain

--- a/include/enfield/Support/DistanceGetter.h
+++ b/include/enfield/Support/DistanceGetter.h
@@ -40,18 +40,12 @@ void efd::DistanceGetter<T>::initImpl() {}
 
 template <typename T>
 void efd::DistanceGetter<T>::checkInitialized() {
-    if (mG == nullptr) {
-        ERR << "Set `Graph` for the DistanceGetter!" << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(mG == nullptr, "Set `Graph` for the DistanceGetter!");
 }
 
 template <typename T>
 void efd::DistanceGetter<T>::checkVertexInGraph(uint32_t u) {
-    if (u >= mG->size()) {
-        ERR << "Out of Bounds: can't calculate distance for: `" << u << "`" << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(u >= mG->size(), "Out of Bounds: can't calculate distance for: `" << u << "`");
 }
 
 template <typename T>

--- a/include/enfield/Support/EnumString.h
+++ b/include/enfield/Support/EnumString.h
@@ -77,11 +77,8 @@ template <typename T, T first, T last, uint32_t padding>
 efd::EnumString<T, first, last, padding>::EnumString(T init) {
     mValue = static_cast<uint32_t>(init);
 
-    if (mValue > static_cast<uint32_t>(last) || mValue < static_cast<uint32_t>(first)) {
-        ERR << "Enum '" << typeid(T).name() << "' doesn't have such value '"
-            << mValue << "'." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(mValue > static_cast<uint32_t>(last) || mValue < static_cast<uint32_t>(first),
+               "Enum '" << typeid(T).name() << "' doesn't have such value '" << mValue << "'.");
 
     mValue = mValue - static_cast<uint32_t>(first);
 }
@@ -98,11 +95,8 @@ efd::EnumString<T, first, last, padding>::EnumString(std::string init) {
 
 template <typename T, T first, T last, uint32_t padding>
 void efd::EnumString<T, first, last, padding>::initImpl(std::string init) {
-    if (!EnumString<T, first, last, padding>::Has(init)) {
-        ERR << "Enum '" << typeid(T).name() << "' doesn't have string '"
-            << init << "'." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf((!EnumString<T, first, last, padding>::Has(init)),
+               "Enum '" << typeid(T).name() << "' doesn't have string '" << init << "'.");
 
     auto it = std::find(mStrVal.begin(), mStrVal.end(), init);
     mValue = std::distance(mStrVal.begin(), it);
@@ -112,11 +106,9 @@ template <typename T, T first, T last, uint32_t padding>
 std::string efd::EnumString<T, first, last, padding>::getStringValue() const {
     auto strSize = mStrVal.size();
 
-    if (strSize < mValue) {
-        ERR << "Enum '" << typeid(T).name() << "' does not have value over "
-            << strSize << ": " << mValue << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(strSize < mValue,
+               "Enum '" << typeid(T).name() << "' does not have value over "
+               << strSize << ": " << mValue);
 
     if (static_cast<uint32_t>(last) - static_cast<uint32_t>(first) + 1 != strSize) {
         WAR << "Enum '" << typeid(T).name() << "' segmented. "

--- a/include/enfield/Support/JsonParser.h
+++ b/include/enfield/Support/JsonParser.h
@@ -34,18 +34,15 @@ namespace efd {
                 }
             }
 
-            if (!check) {
-                ERR << prefix << ": incorrect type for " << JsonTypeVectorString(tys) << ". "
-                    << "Actual: `" << JsonTypeString(keyTy) << "`." << std::endl;
-                EFD_ABORT();
-            }
+            EfdAbortIf(!check,
+                       prefix << ": incorrect type for " << JsonTypeVectorString(tys)
+                       << ". Actual: `" << JsonTypeString(keyTy) << "`.");
         }
 
     /// \brief Gets a \em T instance (wrapped in a \em std::unique_ptr) from the \em Json::Value.
     template <class T> struct JsonBackendParser {
         static std::unique_ptr<T> Parse(const Json::Value& root) {
-            ERR << "Parse method not implemented for '" << typeid(T).name() << "'." << std::endl;
-            EFD_ABORT();
+            EfdAbortIf(true, "Parse method not implemented for '" << typeid(T).name() << "'.");
         }
     };
 

--- a/include/enfield/Support/Registry.h
+++ b/include/enfield/Support/Registry.h
@@ -59,11 +59,7 @@ bool efd::Registry<RetTy, ArgTy, KeyTy, CmpTy>::hasObj(KeyTy key) const {
 
 template <typename RetTy, typename ArgTy, typename KeyTy, typename CmpTy>
 RetTy efd::Registry<RetTy, ArgTy, KeyTy, CmpTy>::createObj(KeyTy key, ArgTy arg) const {
-    if (!hasObj(key)) {
-        ERR << "Trying to create an object not registered." << std::endl; 
-        EFD_ABORT();
-    }
-
+    EfdAbortIf(!hasObj(key), "Trying to create an object not registered." );
     return mCtorMap.at(key)(arg);
 }
 

--- a/include/enfield/Support/WeightedGraph.h
+++ b/include/enfield/Support/WeightedGraph.h
@@ -94,12 +94,7 @@ void efd::WeightedGraph<T>::putEdge(uint32_t i, uint32_t j, T w) {
 template <typename T>
 void efd::WeightedGraph<T>::setW(uint32_t i, uint32_t j, T w) {
     auto pair = std::make_pair(i, j);
-
-    if (mW.find(pair) == mW.end()) {
-        ERR << "Edge not found: `(" << i << ", " << j << ")`." << std::endl;
-        EFD_ABORT();
-    }
-
+    EfdAbortIf(mW.find(pair) == mW.end(), "Edge not found: `(" << i << ", " << j << ")`.");
     mW[pair] = w;
 }
 
@@ -107,10 +102,8 @@ template <typename T>
 T efd::WeightedGraph<T>::getW(uint32_t i, uint32_t j) const {
     auto pair = std::make_pair(i, j);
 
-    if (mW.find(pair) == mW.end()) {
-        ERR << "Edge weight not found for edge: `(" << i << ", " << j << ")`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(mW.find(pair) == mW.end(),
+               "Edge weight not found for edge: `(" << i << ", " << j << ")`.");
 
     return mW.at(pair);
 }
@@ -132,17 +125,13 @@ std::string efd::JsonFields<efd::WeightedGraph<T>>::_WeightLabel_ = "w";
 // ----------------------------- JsonBackendParser -------------------------------
 template <class T>
 T efd::JsonBackendParser<efd::WeightedGraph<T>>::ParseWeight(const Json::Value& v) {
-    ERR << "ParseWeight not implemented for `" << typeid(T).name() << "`."
-        << std::endl;
-    EFD_ABORT();
+    EfdAbortIf(true, "ParseWeight not implemented for `" << typeid(T).name() << "`.");
 }
 
 template <class T>
 std::vector<Json::ValueType>
 efd::JsonBackendParser<efd::WeightedGraph<T>>::GetTysForT() {
-    ERR << "ParseWeight not implemented for `" << typeid(T).name() << "`."
-        << std::endl;
-    EFD_ABORT();
+    EfdAbortIf(true, "ParseWeight not implemented for `" << typeid(T).name() << "`.");
 }
 
 template <class T>

--- a/include/enfield/Support/WeightedSIFinder.h
+++ b/include/enfield/Support/WeightedSIFinder.h
@@ -111,24 +111,17 @@ uint32_t efd::WeightedSIFinder<T>::getFirstFree() {
         if (!matched[u]) return u;
     }
 
-    ERR << "Not enough qubits?" << std::endl;
-    EFD_ABORT();
+    EfdAbortIf(true, "Not enough qubits?");
 }
 
 template <typename T>
 efd::SIFinder::Result efd::WeightedSIFinder<T>::find(Graph::Ref g, Graph::Ref h) {
-    if (!h->isWeighted()) {
-        ERR << "Trying to use weighted partial matching on unweighted graph." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(!h->isWeighted(), "Trying to use weighted partial matching on unweighted graph.");
 
     mG = g;
     mH = dynCast<WeightedGraph<T>>(h);
 
-    if (mH == nullptr) {
-        ERR << "Graph 'h' is not of the specified type." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(mH == nullptr, "Graph 'h' is not of the specified type.");
 
     uint32_t hSize = mH->size();
     uint32_t gSize = mG->size();

--- a/include/enfield/Support/uRefCast.h
+++ b/include/enfield/Support/uRefCast.h
@@ -23,10 +23,9 @@ namespace efd {
                 return std::unique_ptr<T>(toRef);
             }
 
-            ERR << "Failed when casting a std::unique_ptr. `"
-                << typeid(T).name() << "` not a base class of `" << typeid(U).name()
-                << "`." << std::endl;
-            EFD_ABORT();
+            EfdAbortIf(true,
+                       "Failed when casting a std::unique_ptr. `" << typeid(T).name()
+                       << "` not a base class of `" << typeid(U).name() << "`.");
         }
 
     /// \brief Uses the RTTI framework to cast forwardly an unique_ptr.
@@ -42,10 +41,9 @@ namespace efd {
             if (auto toRef = dynCast<T>(fromRef))
                 return std::unique_ptr<T>(toRef);
 
-            ERR << "Failed when casting a std::unique_ptr: from `"
-                << typeid(U).name() << "` to `" << typeid(T).name()
-                << "`." << std::endl;
-            EFD_ABORT();
+            EfdAbortIf(true,
+                       "Failed when casting a std::unique_ptr: from `" << typeid(U).name()
+                       << "` to `" << typeid(T).name() << "`.");
         }
 
     /// \brief Wrapper function that "transforms" a \em std::unique_ptr

--- a/lib/Analysis/Nodes.cpp
+++ b/lib/Analysis/Nodes.cpp
@@ -236,9 +236,7 @@ std::string efd::NDRegDecl::getOperation() const {
     switch (mT) {
         case CONCRETE: return "creg";
         case QUANTUM:  return "qreg";
-        default: 
-                       efd::ERR << "Unknown register type." << std::endl;
-                       efd::EFD_ABORT();
+        default: EfdAbortIf(true, "Unknown register type.");
     }
 }
 
@@ -397,11 +395,7 @@ void efd::NDList::clear() {
 
 void efd::NDList::removeChild(Node::Ref ref) {
     auto it = findChild(ref);
-
-    if (it == end()) {
-		efd::ERR << "Can't remove inexistent child." << std::endl;
-		efd::EFD_ABORT();
-	}
+    EfdAbortIf(it == end(), "Can't remove inexistent child.");
 
     removeChild(it);
     if (mChild.empty())
@@ -1147,11 +1141,7 @@ void efd::NDQOpGen::apply(NodeVisitor::Ref visitor) {
 }
 
 efd::NDQOpGen::IntrinsicKind efd::NDQOpGen::getIntrinsicKind() const {
-    if (!mIsIntrinsic) {
-		efd::ERR << "Trying to get IntrinsicKind of non-intrinsic node." << std::endl;
-		efd::EFD_ABORT();
-	}
-
+    EfdAbortIf(!mIsIntrinsic, "Trying to get IntrinsicKind of non-intrinsic node.");
     return mIK;
 }
 
@@ -1237,9 +1227,7 @@ std::string efd::NDBinOp::getOperation() const {
         case OP_MUL: return "*";
         case OP_DIV: return "/";
         case OP_POW: return "^";
-        default:
-                     efd::ERR << "Unknown binary operation." << std::endl;
-                     efd::EFD_ABORT();
+        default: EfdAbortIf(true, "Unknown binary operation.");
     }
 }
 
@@ -1349,9 +1337,7 @@ std::string efd::NDUnaryOp::getOperation() const {
         case UOP_LN:    return "ln";
         case UOP_SQRT:  return "sqrt";
         case UOP_NEG:   return "-";
-        default:
-                        efd::ERR << "Unknown unary operation." << std::endl;
-                        efd::EFD_ABORT();
+        default: EfdAbortIf(true, "Unknown unary operation.");
     }
 }
 

--- a/lib/Analysis/Parser.yy
+++ b/lib/Analysis/Parser.yy
@@ -409,7 +409,7 @@ static int Parse(std::istream& istr, efd::ASTWrapper& ast, bool forceStdLib) {
             // One should not be able to reach this point.
             // This means that the first node of the AST is neither a
             // statements list nor a qasm version node.
-            efd::EFD_ABORT();
+            EfdAbortIf(true, "AST Root node is neither a `NDQasmVersion` nor a `NDStmtList`.");
         }
 
         for (auto pair : StdLib) {

--- a/lib/Arch/ArchGraph.cpp
+++ b/lib/Arch/ArchGraph.cpp
@@ -34,11 +34,8 @@ std::string ArchGraph::vertexToString(uint32_t i) const {
 }
 
 Node::Ref ArchGraph::getNode(uint32_t i) const {
-    if (i >= mNodes.size()) {
-        ERR << "Node index out of bounds (of `" << mNodes.size()
-            << "`): `" << i << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(i >= mNodes.size(),
+               "Node index out of bounds (of `" << mNodes.size() << "`): `" << i << "`.");
     return mNodes[i].get();
 }
 
@@ -68,10 +65,7 @@ void ArchGraph::putReg(std::string id, std::string size) {
 }
 
 uint32_t ArchGraph::getUId(std::string s) {
-    if (!hasSId(s)) {
-        ERR << "No such vertex with this string id: `" << s << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(!hasSId(s), "No such vertex with this string id: `" << s << "`.");
     return mStrToId[s];
 }
 
@@ -80,11 +74,8 @@ bool ArchGraph::hasSId(std::string s) const {
 }
 
 std::string ArchGraph::getSId(uint32_t i) {
-    if (i >= mId.size()) {
-        ERR << "Vertex index out of bounds (of `" << mId.size() << "`): `"
-            << i << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(i >= mId.size(),
+               "Vertex index out of bounds (of `" << mId.size() << "`): `" << i << "`.");
     return mId[i];
 }
 
@@ -162,11 +153,9 @@ std::unique_ptr<ArchGraph> JsonBackendParser<ArchGraph>::Parse(const Json::Value
         }
     }
 
-    if (totalQubits != qubits) {
-        ERR << "Sum of qubits doesn't match total provided. "
-            << "Sum: " << totalQubits << " != Total: " << qubits << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(totalQubits != qubits,
+               "Sum of qubits doesn't match total provided. Sum: " << totalQubits
+               << " != Total: " << qubits);
     
     auto &adj = root[JsonFields<ArchGraph>::_AdjListLabel_];
     for (uint32_t i = 0; i < qubits; ++i) {

--- a/lib/Support/CommandLine.cpp
+++ b/lib/Support/CommandLine.cpp
@@ -249,11 +249,10 @@ void efd::ParseArguments(const int argc, const char **argv) {
             std::vector<OptBase*>& optVector = Parser->mArgMap[arg];
 
             int32_t toBeConsumed = optVector[0]->argsConsumed();
-            if (i + toBeConsumed >= argc) {
-                ERR << "There should be " << toBeConsumed << " arguments for -" << arg
-                    << ", but there was only " << argc - i << "." << std::endl;
-                EFD_ABORT();
-            }
+
+            EfdAbortIf(i + toBeConsumed >= argc,
+                       "There should be " << toBeConsumed << " arguments for -"
+                       << arg << ", but there was only " << argc - i << ".");
 
             std::vector<std::string> optArgs;
             for (int32_t j = 0; j < toBeConsumed; ++j) {

--- a/lib/Support/ExpTSFinder.cpp
+++ b/lib/Support/ExpTSFinder.cpp
@@ -17,11 +17,9 @@ void efd::ExpTSFinder::genAllAssigns(uint32_t n) {
 
 uint32_t efd::ExpTSFinder::getTargetId(const InverseMap& source,
                                        const InverseMap& target) {
-    if (source.size() != target.size()) {
-        ERR << "The assignment map must be of same size: `"
-            << source.size() << "` and `" << target.size() << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(source.size() != target.size(),
+               "The assignment map must be of same size: `" << source.size()
+               << "` and `" << target.size() << "`.");
 
     int size = source.size();
 

--- a/lib/Support/JsonParser.cpp
+++ b/lib/Support/JsonParser.cpp
@@ -15,7 +15,7 @@ std::string efd::JsonTypeString(const Json::ValueType& ty) {
         case Json::ValueType::objectValue:  return "object";
     }
 
-    EFD_ABORT();
+    EfdAbortIf(true, "Bad JsonCpp ValueType.");
 }
 
 std::string efd::JsonTypeVectorString(const std::vector<Json::ValueType>& tys) {

--- a/lib/Support/Stats.cpp
+++ b/lib/Support/Stats.cpp
@@ -20,11 +20,8 @@ namespace efd {
 }
 
 void efd::StatsPool::addStat(StatBase* stat) {
-    if (hasStat(stat->getName())) {
-        ERR << "Stat with the same name already defined: `" << stat->getName()
-            << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(hasStat(stat->getName()),
+               "Stat with the same name already defined: `" << stat->getName() << "`.");
 
     mMap[stat->getName()] = stat;
 }

--- a/lib/Support/Timer.cpp
+++ b/lib/Support/Timer.cpp
@@ -19,38 +19,22 @@ void efd::Timer::stop() {
 }
 
 uint64_t efd::Timer::getNanoseconds() {
-    if (!mTimed) {
-        ERR << "Trying to get elapsed time from dataless timer." << std::endl;
-        EFD_ABORT();
-    }
-
+    EfdAbortIf(!mTimed, "Trying to get elapsed time from dataless timer.");
     return mDuration.count();
 }
 
 uint64_t efd::Timer::getMicroseconds() {
-    if (!mTimed) {
-        ERR << "Trying to get elapsed time from dataless timer." << std::endl;
-        EFD_ABORT();
-    }
-
+    EfdAbortIf(!mTimed, "Trying to get elapsed time from dataless timer.");
     return std::chrono::duration_cast<std::chrono::microseconds>(mDuration).count();
 }
 
 uint64_t efd::Timer::getMilliseconds() {
-    if (!mTimed) {
-        ERR << "Trying to get elapsed time from dataless timer." << std::endl;
-        EFD_ABORT();
-    }
-
+    EfdAbortIf(!mTimed, "Trying to get elapsed time from dataless timer.");
     return std::chrono::duration_cast<std::chrono::milliseconds>(mDuration).count();
 }
 
 uint64_t efd::Timer::getSeconds() {
-    if (!mTimed) {
-        ERR << "Trying to get elapsed time from dataless timer." << std::endl;
-        EFD_ABORT();
-    }
-
+    EfdAbortIf(!mTimed, "Trying to get elapsed time from dataless timer.");
     return std::chrono::duration_cast<std::chrono::seconds>(mDuration).count();
 }
 

--- a/lib/Support/TokenSwapFinder.cpp
+++ b/lib/Support/TokenSwapFinder.cpp
@@ -5,10 +5,7 @@ using namespace efd;
 TokenSwapFinder::TokenSwapFinder() : mG(nullptr) {}
 
 void TokenSwapFinder::checkGraphSet() {
-    if (mG == nullptr) {
-        ERR << "Set the `Graph` for TokenSwapFinder." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(mG == nullptr, "Set the `Graph` for TokenSwapFinder.");
 }
 
 void TokenSwapFinder::setGraph(Graph::Ref graph) {

--- a/lib/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.cpp
+++ b/lib/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.cpp
@@ -22,12 +22,9 @@ std::vector<Node::Ref> SeqNCandidatesGenerator::generateImpl() {
 }
 
 void SeqNCandidatesGenerator::signalProcessed(Node::Ref node) {
-    if (node != mIt->get()) {
-        ERR << "Node `" << node->toString(false) << "` not the one processed. "
-            << "Actual: `" << (*mIt)->toString(false) << "`." << std::endl;
-        EFD_ABORT();
-    }
-
+    EfdAbortIf(node != mIt->get(),
+               "Node `" << node->toString(false) << "` not the one processed. Actual: `"
+               << (*mIt)->toString(false) << "`.");
     ++mIt;
 }
 
@@ -121,8 +118,7 @@ uint32_t GeoNearestLQPProcessor::getNearest(const Graph::Ref g, uint32_t u, cons
     }
 
     // There is no way we can not find anyone!!
-    ERR << "Can't find any vertice connected to v:" << u << "." << std::endl;
-    EFD_ABORT();
+    EfdAbortIf(true, "Can't find any vertice connected to v:" << u << ".");
 }
 
 void GeoNearestLQPProcessor::process(const Graph::Ref g, Mapping& fromM, Mapping& toM) {

--- a/lib/Transform/Allocators/DynprogQAllocator.cpp
+++ b/lib/Transform/Allocators/DynprogQAllocator.cpp
@@ -83,11 +83,9 @@ efd::StdSolution efd::DynprogQAllocator::buildStdSolution(QModule::Ref qmod) {
             vals[i][j] = { i, nullptr, UNREACH };
 
     for (uint32_t i = 1; i <= depN; ++i) {
-        if (deps[i-1].size() > 1) {
-            ERR << "Trying to allocate qbits to a gate with more than one dependency."
-                << " Gate: `" << deps[i-1].mCallPoint->toString(false) << "`." << std::endl;
-            EFD_ABORT();
-        }
+        EfdAbortIf(deps[i-1].size() > 1,
+                   "Trying to allocate qbits to a gate with more than one dependency."
+                   << " Gate: `" << deps[i-1].mCallPoint->toString(false) << "`.");
 
         efd::Dep dep = deps[i-1].mDeps[0];
 
@@ -152,11 +150,7 @@ efd::StdSolution efd::DynprogQAllocator::buildStdSolution(QModule::Ref qmod) {
     std::vector<std::pair<uint32_t, Mapping>> mappings(depN);
 
     for (int i = depN-1; i >= 0; --i) {
-        if (val->parent == nullptr) {
-            ERR << "Nullptr reached too soon." << std::endl;
-            EFD_ABORT();
-        }
-
+        EfdAbortIf(val->parent == nullptr, "Nullptr reached too soon.");
         mappings[i] = std::make_pair(val->pId, permutations[val->pId]);
         val = val->parent;
     }
@@ -204,11 +198,8 @@ efd::StdSolution efd::DynprogQAllocator::buildStdSolution(QModule::Ref qmod) {
             else {
                 auto path = finder->find(mArchGraph.get(), u, v);
 
-                if (path.size() != 3) {
-                    ERR << "Can't apply a long cnot. Actual path size: `"
-                        << path.size() << "`." << std::endl;
-                    EFD_ABORT();
-                }
+                EfdAbortIf(path.size() != 3,
+                           "Can't apply a long cnot. Actual path size: `" << path.size() << "`.");
 
                 operation = { Operation::K_OP_LCNOT, a, b };
                 operation.mW = inv[path[1]];

--- a/lib/Transform/Allocators/GreedyCktQAllocator.cpp
+++ b/lib/Transform/Allocators/GreedyCktQAllocator.cpp
@@ -110,10 +110,7 @@ StdSolution GreedyCktQAllocator::buildStdSolution(QModule::Ref qmod) {
             }
         }
 
-        if (allocatable.empty()) {
-            ERR << "Every step has to process at least one gate." << std::endl;
-            EFD_ABORT();
-        }
+        EfdAbortIf(allocatable.empty(), "Every step has to process at least one gate.");
 
         // Removing instructions that don't use only one qubit, but do not have any dependencies
         for (auto cnode : allocatable) {
@@ -144,11 +141,9 @@ StdSolution GreedyCktQAllocator::buildStdSolution(QModule::Ref qmod) {
             auto node = cnode->node();
             auto dep = depBuilder.getDeps(node);
 
-            if (dep.size() > 1) {
-                ERR << "Can only allocate gates with at most one depenency."
-                    << " Gate: `" << dep.mCallPoint->toString(false) << "`." << std::endl;
-                EFD_ABORT();
-            }
+            EfdAbortIf(dep.size() > 1,
+                       "Can only allocate gates with at most one depenency."
+                       << " Gate: `" << dep.mCallPoint->toString(false) << "`.");
 
             uint32_t a = dep[0].mFrom, b = dep[0].mTo;
             uint32_t u = mapping[a], v = mapping[b];
@@ -232,10 +227,7 @@ StdSolution GreedyCktQAllocator::buildStdSolution(QModule::Ref qmod) {
                 best = props;
         }
 
-        if (best.cnode.get() == nullptr) {
-            ERR << "There must be a 'best' node." << std::endl;
-            EFD_ABORT();
-        }
+        EfdAbortIf(best.cnode.get() == nullptr, "There must be a 'best' node.");
 
         // Allocate best node;
         // Setting the 'stop' flag;

--- a/lib/Transform/Allocators/JKUQAllocator.cpp
+++ b/lib/Transform/Allocators/JKUQAllocator.cpp
@@ -216,8 +216,7 @@ AStarNode JKUQAllocator::astar(std::queue<uint32_t>& cnotLayersIdQ,
                 inverse[pair.first] = a;
                 inverse[pair.second] = b;
             } else {
-                ERR << "No available edges!" << std::endl;
-                EFD_ABORT();
+                EfdAbortIf(true, "No available edges!");
             }
         } else if (mapping[a] == _undef || mapping[b] == _undef) {
             uint32_t unmapped;

--- a/lib/Transform/Allocators/QbitAllocator.cpp
+++ b/lib/Transform/Allocators/QbitAllocator.cpp
@@ -151,9 +151,7 @@ uint32_t QbitAllocator::getCXCost(uint32_t u, uint32_t v) {
     if (mArchGraph->hasEdge(u, v)) return mCXCost;
     if (mArchGraph->hasEdge(v, u)) return mCXCost + (4 * mHCost);
 
-    ERR << "There is no edge (" << u << ", " << v << ") in the architecture graph."
-        << std::endl;
-    EFD_ABORT();
+    EfdAbortIf(true, "There is no edge (" << u << ", " << v << ") in the architecture graph.");
 }
 
 uint32_t QbitAllocator::getSwapCost(uint32_t u, uint32_t v) {

--- a/lib/Transform/Allocators/SabreQAllocator.cpp
+++ b/lib/Transform/Allocators/SabreQAllocator.cpp
@@ -75,12 +75,10 @@ SabreQAllocator::allocateWithInitialMapping(const Mapping& initialMapping,
                             if (cNode->numberOfXbits() > 1) {
                                 auto deps = depBuilder.getDeps(node);
 
-                                if (deps.size() != 1) {
-                                    ERR << "Unable to handle `" << deps.size() << "` dependencies "
-                                        << "in: `" << node->toString(false) << "`."
-                                        << std::endl;
-                                    EFD_ABORT();
-                                }
+                                EfdAbortIf(deps.size() != 1,
+                                           "Unable to handle `" << deps.size()
+                                           << "` dependencies in: `" << node->toString(false)
+                                           << "`.");
 
                                 auto dep = deps[0];
                                 uint32_t u = mapping[dep.mFrom], v = mapping[dep.mTo];

--- a/lib/Transform/Allocators/Simple/QbitterSolBuilder.cpp
+++ b/lib/Transform/Allocators/Simple/QbitterSolBuilder.cpp
@@ -29,11 +29,8 @@ efd::StdSolution efd::QbitterSolBuilder::build
 
             auto path = finder->find(g, u, v);
 
-            if (path.size() != 3) {
-                ERR << "Can't apply a long cnot. Path size: `"
-                    << path.size() << "`." << std::endl;
-                EFD_ABORT();
-            }
+            EfdAbortIf(path.size() != 3,
+                       "Can't apply a long cnot. Path size: `" << path.size() << "`.");
 
             operation.mW = inv[path[1]];
         }

--- a/lib/Transform/ArchVerifierPass.cpp
+++ b/lib/Transform/ArchVerifierPass.cpp
@@ -53,57 +53,45 @@ bool ArchVerifierVisitor::visitNDQOp(NDQOp::Ref qop) {
     }
 
     if (IsCNOTGateCall(qop)) {
-        if (qUIds.size() != 2) {
-            ERR << "CNOT call must have 2 quantum qubits. Actual: `"
-                << qop->toString(false) << "`." << std::endl;
-            EFD_ABORT();
-        }
+        EfdAbortIf(qUIds.size() != 2,
+                   "CNOT call must have 2 quantum qubits. Actual: `"
+                   << qop->toString(false) << "`.");
 
         success = checkCNOT({ qUIds[0], qUIds[1] });
 
     } else if (IsIntrinsicGateCall(qop)) {
         auto gen = dynCast<NDQOpGen>(qop);
 
-        if (gen == nullptr) {
-            ERR << "Intrinsic call not generic operation!? Actual: `"
-                << qop->toString(false) << "`." << std::endl;
-            EFD_ABORT();
-        }
+        EfdAbortIf(gen == nullptr,
+                   "Intrinsic call not generic operation!? Actual: `"
+                   << qop->toString(false) << "`.");
 
-        if (!gen->isIntrinsic()) {
-            ERR << "Intrinsic call not marked as intrinsic!? Actual: `"
-                << qop->toString(false) << "`." << std::endl;
-            EFD_ABORT();
-        }
+        EfdAbortIf(!gen->isIntrinsic(),
+                   "Intrinsic call not marked as intrinsic!? Actual: `"
+                   << qop->toString(false) << "`.");
 
         switch (gen->getIntrinsicKind()) {
             case NDQOpGen::K_INTRINSIC_SWAP:
-                if (qUIds.size() != 2) {
-                    ERR << "SWAP call must have 2 quantum qubits. Actual: `"
-                        << qUIds.size() << "`." << std::endl;
-                    EFD_ABORT();
-                }
+                EfdAbortIf(qUIds.size() != 2,
+                           "SWAP call must have 2 quantum qubits. Actual: `"
+                           << qUIds.size() << "`.");
 
                 success = checkCNOT({ qUIds[0], qUIds[1] }) || checkCNOT({ qUIds[1], qUIds[0] });
                 break;
 
             case NDQOpGen::K_INTRINSIC_LCX:
-                if (qUIds.size() != 3) {
-                    ERR << "LCX call must have 3 quantum qubits. Actual: `"
-                        << qUIds.size() << "`." << std::endl;
-                    EFD_ABORT();
-                }
+                EfdAbortIf(qUIds.size() != 3,
+                           "LCX call must have 3 quantum qubits. Actual: `"
+                           << qUIds.size() << "`.");
 
                 success = (checkCNOT({ qUIds[0], qUIds[1] }) || checkCNOT({ qUIds[1], qUIds[0] })) &&
                           (checkCNOT({ qUIds[1], qUIds[2] }) || checkCNOT({ qUIds[2], qUIds[1] }));
                 break;
 
             case NDQOpGen::K_INTRINSIC_REV_CX:
-                if (qUIds.size() != 2) {
-                    ERR << "Reversal call must have 2 quantum qubits. Actual: `"
-                        << qUIds.size() << "`." << std::endl;
-                    EFD_ABORT();
-                }
+                EfdAbortIf(qUIds.size() != 2,
+                           "Reversal call must have 2 quantum qubits. Actual: `"
+                           << qUIds.size() << "`.");
 
                 success = checkCNOT({ qUIds[1], qUIds[0] });
                 break;

--- a/lib/Transform/CircuitGraph.cpp
+++ b/lib/Transform/CircuitGraph.cpp
@@ -19,9 +19,9 @@ Xbit::Xbit(uint32_t realId, uint32_t qubits, uint32_t cbits) {
         mId = qubits - realId;
         mType = Type::CLASSIC;
     } else {
-        ERR << "Bit `" << realId << "` is not quantum (until `" << qubits << "`) nor "
-            << "classical (until `" << qubits + cbits << "`)." << std::endl;
-        EFD_ABORT();
+        EfdAbortIf(true,
+                   "Bit `" << realId << "` is not quantum (until `" << qubits
+                   << "`) nor classical (until `" << qubits + cbits << "`).");
     }
 }
 
@@ -33,20 +33,15 @@ uint32_t Xbit::getRealId(uint32_t qubits, uint32_t cbits) {
 
     switch (mType) {
         case Type::QUANTUM:
-            if (id >= qubits) {
-                ERR <<  "Qubit with id `" << id << "`, but max `"
-                    << qubits - 1 << "`." << std::endl;
-                EFD_ABORT();
-            }
+            EfdAbortIf(id >= qubits,
+                       "Qubit with id `" << id << "`, but max `" << qubits - 1 << "`.");
             break;
 
         case Type::CLASSIC:
             id = id + qubits;
-            if (id >= qubits + cbits) {
-                ERR <<  "Classical bit with id `" << id << "`, but max `"
-                    << qubits + cbits - 1 << "`." << std::endl;
-                EFD_ABORT();
-            }
+            EfdAbortIf(id >= qubits + cbits,
+                       "Classical bit with id `" << id << "`, but max `"
+                       << qubits + cbits - 1 << "`.");
             break;
     }
 
@@ -186,10 +181,7 @@ void CircuitGraph::init(uint32_t qubits, uint32_t cbits) {
 }
 
 void CircuitGraph::checkInitialized() {
-    if (!mInit) {
-        ERR << "Trying to append a node to an uninitialized CircuitGraph." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(!mInit, "Trying to append a node to an uninitialized CircuitGraph.");
 }
 
 uint32_t CircuitGraph::getQSize() const {

--- a/lib/Transform/DependencyBuilderPass.cpp
+++ b/lib/Transform/DependencyBuilderPass.cpp
@@ -53,11 +53,8 @@ const efd::DependencyBuilder::DepsVector* efd::DependencyBuilder::getDepsVector
     const DepsVector* deps = &mGDeps;
 
     if (gate != nullptr) {
-        if (mLDeps.find(gate) == mLDeps.end()) {
-            efd::ERR << "No dependencies for this gate: `"
-                << gate->getId()->getVal() << "`." << std::endl;
-            efd::EFD_ABORT();
-        }
+        EfdAbortIf(mLDeps.find(gate) == mLDeps.end(),
+                   "No dependencies for this gate: `" << gate->getId()->getVal() << "`.");
 
         deps = &mLDeps.at(gate);
     }
@@ -91,11 +88,10 @@ efd::DependencyBuilder::DepsVector& efd::DependencyBuilder::getDependencies
 }
 
 const efd::Dependencies efd::DependencyBuilder::getDeps(Node* ref) const {
-    if (mIDeps.find(ref) == mIDeps.end()) {
-        std::string refStr = (ref == nullptr) ? "nullptr" : ref->toString(false);
-        efd::ERR << "Instruction never seen before: `" << refStr << "`." << std::endl;
-        efd::EFD_ABORT();
-    }
+    EfdAbortIf(mIDeps.find(ref) == mIDeps.end(),
+               "Instruction never seen before: `" <<
+               ((ref == nullptr) ? "nullptr" : ref->toString(false))
+               << "`.");
 
     return mIDeps.at(ref);
 }
@@ -145,12 +141,7 @@ efd::NDGateDecl::Ref efd::DependencyBuilderVisitor::getParentGate(Node::Ref ref)
     }
 
     auto gate = dynCast<NDGateDecl>(goplist->getParent());
-
-    if (gate == nullptr) {
-        efd::ERR << "NDGOpList is owned by a no node." << std::endl;
-        efd::EFD_ABORT();
-    }
-
+    EfdAbortIf(gate == nullptr, "NDGOpList is owned by a no node.");
     return gate;
 }
 
@@ -189,11 +180,8 @@ void efd::DependencyBuilderVisitor::visit(NDQOpGen::Ref ref) {
     Node::Ref node = mMod.getQGate(ref->getId()->getVal());
     NDGateDecl::Ref gRef = dynCast<NDGateDecl>(node);
 
-    if (gRef == nullptr) {
-        std::string nodeStr = (node == nullptr) ? "nullptr" : node->toString(false);
-        efd::ERR << "There is no quantum gate with this id: `" << nodeStr << "`." << std::endl;
-        efd::EFD_ABORT();
-    }
+    EfdAbortIf(gRef == nullptr,
+               "There is no quantum gate with this id: `" << node->toString(false) << "`.");
 
     auto& gDeps = mDepBuilder.mLDeps[gRef];
     Dependencies thisDeps { {}, ref };

--- a/lib/Transform/Driver.cpp
+++ b/lib/Transform/Driver.cpp
@@ -38,12 +38,10 @@ QModule::uRef efd::Compile(QModule::uRef qmod, CompilationSettings settings) {
     auto xbitPass = PassCache::Get<XbitToNumberWrapperPass>(qmod.get());
     auto xbitToNumber = xbitPass->getData(); 
 
-    if (xbitToNumber.getQSize() > settings.archGraph->size()) {
-        ERR << "Using more qbits than the maximum permitted by the architecture (max `"
-            << settings.archGraph->size() << "`): `" << xbitToNumber.getQSize()
-            << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(xbitToNumber.getQSize() > settings.archGraph->size(),
+               "Using more qbits than the maximum permitted by the architecture (max `"
+               << settings.archGraph->size() << "`): `"
+               << xbitToNumber.getQSize() << "`.");
 
     auto allocPass = CreateQbitAllocator(settings.allocator, settings.archGraph);
     allocPass->setGateWeightMap(settings.gWeightMap);

--- a/lib/Transform/ErrorRateCalculationPass.cpp
+++ b/lib/Transform/ErrorRateCalculationPass.cpp
@@ -8,10 +8,8 @@ uint8_t efd::ErrorRateCalculationPass::ID = 0;
 ErrorRateCalculationPass::ErrorRateCalculationPass(ArchGraph::sRef arch) : mArchGraph(arch) {}
 
 bool ErrorRateCalculationPass::run(QModule::Ref qmod) {
-    if (mArchGraph.get() == nullptr) {
-        ERR << "mArchGraph not defined for `ErrorRateCalculationPass`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(mArchGraph.get() == nullptr,
+               "mArchGraph not defined for `ErrorRateCalculationPass`.");
 
     double result = 1;
 

--- a/lib/Transform/FlattenPass.cpp
+++ b/lib/Transform/FlattenPass.cpp
@@ -140,21 +140,13 @@ static bool HasAnyNDIdChild(Node::Ref ref) {
 
 static NDRegDecl::Ref GetDeclFromId(const QModule::Ref qmod, Node::Ref ref) {
     NDId::Ref refId = dynCast<NDId>(ref);
-
-    if (refId == nullptr) {
-        std::string refStr = (ref == nullptr) ? "nullptr" : ref->toString(false);
-        ERR << "Not an Id: `" << refStr << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(refId == nullptr, "Not an Id: `" << ref->toString(false) << "`.");
 
     auto node = qmod->getQVar(refId->getVal());
     NDRegDecl::Ref refDecl = dynCast<NDRegDecl>(node);
 
-    if (refDecl == nullptr) {
-        std::string nodeStr = (node == nullptr) ? "nullptr" : node->toString(false);
-        ERR << "Not an NDRegDecl: `" << nodeStr << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(refDecl == nullptr,
+               "Not an NDRegDecl: `" << node->toString(false) << "`.");
 
     return refDecl;
 }

--- a/lib/Transform/LayerBasedOrderingWrapperPass.cpp
+++ b/lib/Transform/LayerBasedOrderingWrapperPass.cpp
@@ -3,11 +3,10 @@
 #include "enfield/Support/Defs.h"
 
 uint32_t efd::LayerBasedOrderingWrapperPass::getNodeId(Node::Ref ref) {
-    if (mStmtId.find(ref) == mStmtId.end()) {
-        std::string refStr = (ref == nullptr) ? "nullptr" : ref->toString(false);
-        efd::ERR << "Unknown node: `" << refStr << "`." << std::endl;
-        efd::EFD_ABORT();
-    }
+    EfdAbortIf(mStmtId.find(ref) == mStmtId.end(),
+               "Unknown node: `"
+               << ((ref == nullptr) ? "nullptr" : ref->toString(false))
+               << "`.");
 
     return mStmtId[ref];
 }

--- a/lib/Transform/QModule.cpp
+++ b/lib/Transform/QModule.cpp
@@ -53,11 +53,10 @@ void efd::QModule::removeAllQRegs() {
 efd::QModule::Iterator efd::QModule::findStatement(Node::Ref ref) {
     auto it = mStatements->findChild(ref);
 
-    if (it == mStatements->end()) {
-        std::string nodeStr = (ref == nullptr) ? "nullptr" : ref->toString(false);
-        ERR << "Node not in the main statement list: `" << nodeStr << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(it == mStatements->end(),
+               "Node not in the main statement list: `"
+               << ((ref == nullptr) ? "nullptr" : ref->toString(false))
+               << "`.");
 
     return it;
 }
@@ -67,11 +66,8 @@ void efd::QModule::removeStatement(Iterator it) {
 }
 
 efd::QModule::Iterator efd::QModule::inlineCall(NDQOp::Ref call) {
-    if (!call->isGeneric()) {
-        ERR << "Trying to inline a non-generic call: `" << call->toString(false)
-            << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(!call->isGeneric(),
+               "Trying to inline a non-generic call: `" << call->toString(false) << "`.");
 
     Node::Ref stmt = call;
     auto parent = call->getParent();
@@ -120,11 +116,10 @@ efd::QModule::Iterator efd::QModule::replaceStatement
 (Node::Ref stmt, std::vector<Node::uRef> stmts) {
     auto it = mStatements->findChild(stmt);
 
-    if (it == mStatements->end()) {
-        std::string stmtStr = (stmt == nullptr) ? "nullptr" : stmt->toString(false);
-        ERR << "Trying to replace a non-existing statement: `" << stmtStr << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(it == mStatements->end(),
+               "Trying to replace a non-existing statement: `"
+               << ((stmt == nullptr) ? "nullptr" : stmt->toString(false))
+               << "`.");
 
     uint32_t stmtsSize = stmts.size();
     if (!stmts.empty()) {
@@ -140,24 +135,15 @@ void efd::QModule::clearStatements() {
 }
 
 efd::Node::Ref efd::QModule::getStatement(uint32_t i) {
-    if (i >= mStatements->getChildNumber()) {
-        ERR << "Out of bounds access (of `" << mStatements->getChildNumber()
-            << "`): `" << i << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(i >= mStatements->getChildNumber(),
+               "Out of bounds access (of `" << mStatements->getChildNumber()
+               << "`): `" << i << "`.");
     return mStatements->getChild(i);
 }
 
 void efd::QModule::insertGate(NDGateSign::uRef gate) {
-    if (gate.get() == nullptr) {
-        ERR << "Trying to insert a 'nullptr' gate." << std::endl;
-        EFD_ABORT();
-    }
-
-    if (gate->getId() == nullptr) {
-        ERR << "Trying to insert a gate with 'nullptr' id." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(gate.get() == nullptr, "Trying to insert a 'nullptr' gate.");
+    EfdAbortIf(gate->getId() == nullptr, "Trying to insert a gate with 'nullptr' id.");
 
     std::string id = gate->getId()->getVal();
 
@@ -306,17 +292,13 @@ std::string efd::QModule::toString(bool pretty, bool printGates) const {
 
 efd::Node::Ref efd::QModule::getQVar(std::string id, NDGateDecl::Ref gate) const {
     if (gate != nullptr) {
-        if (mGateIdMap.find(gate) == mGateIdMap.end()) {
-            ERR << "No such gate found: `" << gate->getId()->getVal() << "`." << std::endl;
-            EFD_ABORT();
-        }
+        EfdAbortIf(mGateIdMap.find(gate) == mGateIdMap.end(),
+                   "No such gate found: `" << gate->getId()->getVal() << "`.");
 
         const IdMap& idMap = mGateIdMap.at(gate);
-        if (idMap.find(id) == idMap.end()) {
-            ERR << "No such id inside this gate (`" << gate->getId()->getVal()
-                << "`): `" << id << "`." << std::endl;
-            EFD_ABORT();
-        }
+        EfdAbortIf(idMap.find(id) == idMap.end(),
+                   "No such id inside this gate (`" << gate->getId()->getVal()
+                   << "`): `" << id << "`.");
 
         return idMap.at(id);
     }
@@ -341,10 +323,7 @@ bool efd::QModule::hasQVar(std::string id, NDGateDecl::Ref gate) const {
 }
 
 efd::NDGateSign::Ref efd::QModule::getQGate(std::string id) const {
-    if (mGatesMap.find(id) == mGatesMap.end()) {
-        ERR << "Gate not found: `" << id << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(mGatesMap.find(id) == mGatesMap.end(), "Gate not found: `" << id << "`.");
     return mGatesMap.at(id).get();
 }
 

--- a/lib/Transform/RenameQbitsPass.cpp
+++ b/lib/Transform/RenameQbitsPass.cpp
@@ -28,12 +28,7 @@ namespace efd {
 
 efd::Node::uRef efd::RenameQbitVisitor::getNodeFromOld(Node::Ref old) {
     std::string id = old->toString();
-
-    if (mAMap.find(id) == mAMap.end()) {
-        ERR << "Node not found for id/idref: `" << id << "`." << std::endl;
-        EFD_ABORT();
-    }
-
+    EfdAbortIf(mAMap.find(id) == mAMap.end(), "Node not found for id/idref: `" << id << "`.");
     return mAMap[id]->clone();
 }
 

--- a/lib/Transform/ReverseEdgesPass.cpp
+++ b/lib/Transform/ReverseEdgesPass.cpp
@@ -55,10 +55,8 @@ void efd::ReverseEdgesVisitor::visit(NDQOpCX::Ref ref) {
 void efd::ReverseEdgesVisitor::visit(NDQOpGen::Ref ref) {
     if (ref->getId()->getVal() == "cx") {
         // Have to come up a way to overcome this.
-        if (ref->getQArgs()->getChildNumber() != 2) {
-            ERR << "CNot gate malformed: `" << ref->toString(false) << "`." << std::endl;
-            EFD_ABORT();
-        }
+        EfdAbortIf(ref->getQArgs()->getChildNumber() != 2,
+                   "CNot gate malformed: `" << ref->toString(false) << "`.");
 
         NDList* qargs = ref->getQArgs();
         uint32_t uidLhs = mG->getUId(qargs->getChild(0)->toString());

--- a/lib/Transform/SemanticVerifierPass.cpp
+++ b/lib/Transform/SemanticVerifierPass.cpp
@@ -252,9 +252,9 @@ void SemanticVerifierVisitor::visitNDQOp(NDQOp::Ref tgtQOp, NDIfStmt::Ref tgtIfS
             mSuccess = src->getQArgs()->getChildNumber() == tgt->getQArgs()->getChildNumber();
 
         } else {
-            std::string str = (srcQOp == nullptr) ? "nullptr" : srcQOp->toString(false);
-            ERR << "Node is neither CNOT nor Barrier. Actual: `" << str << "`." << std::endl;
-            EFD_ABORT();
+            EfdAbortIf(true,
+                       "Node is neither CNOT nor Barrier. Actual: `"
+                       << srcQOp->toString(false) << "`.");
         }
 
     } else {

--- a/lib/Transform/XbitToNumberPass.cpp
+++ b/lib/Transform/XbitToNumberPass.cpp
@@ -9,40 +9,29 @@
 // --------------------- XbitToNumber ------------------------
 const efd::XbitToNumber::XbitMap&
 efd::XbitToNumber::getQbitMap(NDGateDecl::Ref gate) const {
-    if (gate != nullptr && lidQMap.find(gate) == lidQMap.end()) {
-        ERR << "Trying to get an unknown gate information: `" << gate->getId()->getVal()
-            << "`." << std::endl;
-        EFD_ABORT();
-    }
-
+    EfdAbortIf(gate != nullptr && lidQMap.find(gate) == lidQMap.end(),
+               "Trying to get an unknown gate information: `" << gate->getId()->getVal() << "`.");
     return (gate == nullptr) ? gidQMap : lidQMap.at(gate);
 }
 
 std::vector<uint32_t> efd::XbitToNumber::getRegUIds(std::string id) const {
-    if (gidRegMap.find(id) == gidRegMap.end()) {
-        ERR << "Register not found: `" << id << "`." << std::endl;
-        EFD_ABORT();
-    }
-
+    EfdAbortIf(gidRegMap.find(id) == gidRegMap.end(), "Register not found: `" << id << "`.");
     return gidRegMap.at(id);
 }
 
 uint32_t efd::XbitToNumber::getQUId(std::string id, NDGateDecl::Ref gate) const {
     auto& map = getQbitMap(gate);
-    if (map.find(id) == map.end()) {
-        std::string gateId = (gate == nullptr) ? "nullptr" : gate->getId()->getVal();
-        ERR << "Qubit id not found inside gate (`" << gateId << "`): `" << id << "`." << std::endl;
-        std::exit(12);
-        // EFD_ABORT();
-    }
+
+    EfdAbortIf(map.find(id) == map.end(),
+               "Qubit id not found inside gate (`"
+               << ((gate == nullptr) ? "nullptr" : gate->getId()->getVal()) << "`): `"
+               << id << "`.");
+
     return map.at(id).key;
 }
 
 uint32_t efd::XbitToNumber::getCUId(std::string id) const {
-    if (gidCMap.find(id) == gidCMap.end()) {
-        ERR << "Classical bit id not found: `" << id << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(gidCMap.find(id) == gidCMap.end(), "Classical bit id not found: `" << id << "`.");
     return gidCMap.at(id).key;
 }
 
@@ -57,33 +46,28 @@ uint32_t efd::XbitToNumber::getCSize() const {
 
 std::string efd::XbitToNumber::getQStrId(uint32_t id, NDGateDecl::Ref gate) const {
     auto& map = getQbitMap(gate);
-    if (id >= map.size()) {
-        ERR << "Id trying to access out of bounds value (of `" << map.size() << "`): `"
-            << id << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(id >= map.size(),
+               "Id trying to access out of bounds value (of `"
+               << map.size() << "`): `" << id << "`.");
 
     for (auto it = map.begin(), end = map.end(); it != end; ++it) {
         if (it->second.key == id) return it->first;
     }
 
-    std::string gateId = (gate == nullptr) ? "nullptr" : gate->getId()->getVal();
-    ERR << "UId not found inside gate (`" << gateId << "`): `" << id << "`." << std::endl;
-    EFD_ABORT();
+    EfdAbortIf(true,
+               "UId not found inside gate (`"
+               << ((gate == nullptr) ? "nullptr" : gate->getId()->getVal())
+               << "`): `" << id << "`.");
 }
 
 std::string efd::XbitToNumber::getCStrId(uint32_t id) const {
-    if (id >= gidCMap.size()) {
-        ERR << "Classical bit id not found: `" << id << "`." << std::endl;
-        EFD_ABORT();
-    }
+    EfdAbortIf(id >= gidCMap.size(), "Classical bit id not found: `" << id << "`.");
 
     for (auto it = gidCMap.begin(), end = gidCMap.end(); it != end; ++it) {
         if (it->second.key == id) return it->first;
     }
 
-    ERR << "UId not found: `" << id << "`." << std::endl;
-    EFD_ABORT();
+    EfdAbortIf(true, "UId not found: `" << id << "`.");
 }
 
 efd::Node::Ref efd::XbitToNumber::getQNode(uint32_t id, NDGateDecl::Ref gate) const {


### PR DESCRIPTION
Big commit that changes all instances of:

```
if (condition) {
    ERR << "Some error message. Culprit: " << culprit.toString() << "." << std::endl;
    EFD_ABORT();
}
```

to:

```
EfdAbortIf(condition, "Some error message. Culprit: " << culprit.toString() << ".");
```

with the same behaviour.