### PR TITLE
[BoundedMappingTreeQAllocator]: timing fix.

### DIFF
--- a/include/enfield/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.h
+++ b/include/enfield/Transform/Allocators/BMT/DefaultBMTQAllocatorImpl.h
@@ -13,7 +13,7 @@ namespace efd {
             Node::Iterator mIt;
 
         protected:
-            void initializeImpl() override;
+            void initImpl() override;
             bool finishedImpl() override;
             std::vector<Node::Ref> generateImpl() override;
 
@@ -48,7 +48,7 @@ namespace efd {
             bmt::Vector distanceFrom(Graph::Ref g, uint32_t u);
 
         protected:
-            void preprocess() override;
+            void initImpl() override;
             uint32_t estimateImpl(const Mapping& fromM, const Mapping& toM) override;
 
         public:
@@ -61,16 +61,19 @@ namespace efd {
     /// \brief Forces \em toM to map all qubits mapped in \em fromM.
     class GeoNearestLQPProcessor : public LiveQubitsPreProcessor {
         private:
+            bmt::Matrix mDist;
             uint32_t mPQubits;
             uint32_t mVQubits;
 
-            uint32_t getNearest(const Graph::Ref g, uint32_t u, const InverseMap& inv);
+            uint32_t getNearest(uint32_t u, const InverseMap& inv);
+
+        protected:
+            void initImpl() override;
+            void processImpl(Mapping& fromM, Mapping& toM) override;
 
         public:
             typedef GeoNearestLQPProcessor* Ref;
             typedef std::unique_ptr<GeoNearestLQPProcessor> uRef;
-
-            void process(const Graph::Ref g, Mapping& fromM, Mapping& toM) override;
 
             static uRef Create();
     };

--- a/include/enfield/Transform/Allocators/BMT/ImprovedBMTQAllocatorImpl.h
+++ b/include/enfield/Transform/Allocators/BMT/ImprovedBMTQAllocatorImpl.h
@@ -35,7 +35,7 @@ namespace efd {
             void advanceCNode(CircuitGraph::CircuitNode::Ref cnode);
 
         protected:
-            void initializeImpl() override;
+            void initImpl() override;
             bool finishedImpl() override;
             std::vector<Node::Ref> generateImpl() override;
 

--- a/include/enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h
+++ b/include/enfield/Transform/Allocators/BoundedMappingTreeQAllocator.h
@@ -80,14 +80,12 @@ namespace efd {
         virtual ~NodeCandidatesGenerator() = default;
         NodeCandidatesGenerator();
 
-        /// \brief Sets the `QModule` to be iterated.
-        void setQModule(QModule::Ref qmod);
         /// \brief Returns the next collection of candidates.
         std::vector<Node::Ref> generate();
         /// \brief Returns whether we have finished processing the nodes.
         bool finished();
         /// \brief Initializes the generator.
-        void initialize();
+        void init(QModule::Ref qmod);
         /// \brief Signals the generator which node has been selected.
         virtual void signalProcessed(Node::Ref node);
 
@@ -98,7 +96,7 @@ namespace efd {
         protected:
             QModule::Ref mMod;
 
-            virtual void initializeImpl() = 0;
+            virtual void initImpl();
             virtual bool finishedImpl() = 0;
             virtual std::vector<Node::Ref> generateImpl() = 0;
     };
@@ -111,7 +109,7 @@ namespace efd {
         virtual ~CandidateSelector() = default;
         /// \brief Selects \em maxCandidates from \em candidates.
         virtual bmt::MCandidateVector select(uint32_t maxCandidates,
-                                            const bmt::MCandidateVector& candidates) = 0;
+                                             const bmt::MCandidateVector& candidates) = 0;
     };
 
     /// \brief Interface for estimating the number of swaps in phase 2.
@@ -122,16 +120,16 @@ namespace efd {
         virtual ~SwapCostEstimator() = default;
         SwapCostEstimator();
 
-        /// \brief Sets the `Graph`.
-        void setGraph(Graph::Ref g);
+        /// \brief Initializes the structure with \p g.
+        void init(Graph::Ref g);
         /// \brief Estimates the number of swaps to go from \em fromM to \toM.
         uint32_t estimate(const Mapping& fromM, const Mapping& toM);
 
         protected:
             Graph::Ref mG;
 
-            void checkGraphSet();
-            virtual void preprocess() = 0;
+            void checkInitialized();
+            virtual void initImpl() = 0;
             virtual uint32_t estimateImpl(const Mapping& fromM,
                                           const Mapping& toM) = 0;
     };
@@ -141,10 +139,22 @@ namespace efd {
     struct LiveQubitsPreProcessor {
         typedef LiveQubitsPreProcessor* Ref;
         typedef std::unique_ptr<LiveQubitsPreProcessor> uRef;
+
         virtual ~LiveQubitsPreProcessor() = default;
+        LiveQubitsPreProcessor();
+
+        /// \brief Initializes the structure with \p g.
+        void init(Graph::Ref g);
         /// \brief Processes `Mapping` \em toM, based on the graph \em g and on the
         /// last `Mapping` \em fromM.
-        virtual void process(const Graph::Ref g, Mapping& fromM, Mapping& toM) = 0;
+        void process(Mapping& fromM, Mapping& toM);
+
+        protected:
+            Graph::Ref mG;
+
+            void checkInitialized();
+            virtual void initImpl() = 0;
+            virtual void processImpl(Mapping& fromM, Mapping& toM) = 0;
     };
 
     /// \brief Selects a number of line numbers from the memoized matrix. 

--- a/lib/Transform/Allocators/BMT/ImprovedBMTQAllocatorImpl.cpp
+++ b/lib/Transform/Allocators/BMT/ImprovedBMTQAllocatorImpl.cpp
@@ -20,7 +20,7 @@ void CircuitCandidatesGenerator::advanceCNode(CircuitGraph::CircuitNode::Ref cno
     }
 }
 
-void CircuitCandidatesGenerator::initializeImpl() {
+void CircuitCandidatesGenerator::initImpl() {
     mCGraph = PassCache::Get<CircuitGraphBuilderPass>(mMod)->getData();
     mIt = mCGraph.build_iterator();
     mXbitSize = mCGraph.size();


### PR DESCRIPTION
Optimized distance cost when processing the mappings for LiveQubits.
Instead of running a BFS everytime, we preprocess the distances, and get
the available qubit with the smallest distance (basically what we do,
but optimized for locallity).